### PR TITLE
fix string input in csv source2dicts

### DIFF
--- a/ianalyzer_readers/readers/csv.py
+++ b/ianalyzer_readers/readers/csv.py
@@ -76,7 +76,7 @@ class CSVReader(Reader):
         if isinstance(source, str):
             filename = source
             metadata = {}
-        if isinstance(source, bytes):
+        elif isinstance(source, bytes):
             raise NotImplementedError()
         else:
             filename, metadata = source

--- a/tests/mock_csv_corpus.py
+++ b/tests/mock_csv_corpus.py
@@ -15,9 +15,7 @@ class TestCSVReader(CSVReader):
     def sources(self, **kwargs):
         for filename in os.listdir(self.data_directory):
             full_path = os.path.join(self.data_directory, filename)
-            yield full_path, {
-                'filename': filename
-            }
+            yield full_path
 
     fields = [
         Field(

--- a/tests/test_csvcorpus.py
+++ b/tests/test_csvcorpus.py
@@ -49,8 +49,20 @@ def test_csv():
     corpus = TestCSVReader()
 
     sources = list(corpus.sources())
-    assert len(sources) == 1 and sources[0][1] == {'filename': 'example.csv'}
+    assert len(sources) == 1
 
     docs = corpus.source2dicts(sources[0])
     for doc, target in zip(docs, target_documents):
         assert doc == target
+
+def test_csv_supported_source_types():
+    corpus = TestCSVReader()
+    source = next(corpus.sources())
+    assert isinstance(source, str)
+
+    # should work with a path as the source
+    list(corpus.source2dicts(source))
+
+    # should work with a path + metadata as the source
+    source_with_metadata = source, {}
+    list(corpus.source2dicts(source_with_metadata))


### PR DESCRIPTION
Fixes an issue with the CSV reader, which did not work when `sources()` generates strings (instead of tuples with a path + metadata).