### PR TITLE
Feature/redesign xml reader

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -35,3 +35,9 @@ __Module:__ `ianalyzer_readers.readers.html`
 __Module:__ `ianalyzer_readers.extract`
 
 ::: ianalyzer_readers.extract
+
+## XML tags
+
+__Module:__ `ianalyzer_readers.xml_tag`
+
+::: ianalyzer_readers.xml_tag

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -261,8 +261,8 @@ class XML(Extractor):
     - Choose where to start searching. The default searching point is the entry tag
         for the document, but you can also start from the top of the document by setting
         `toplevel`.
-    - Describe the tag you need as an XMLTag object. You can also use a chain of queries by
-        providing a list.
+    - Describe the tag(s) you're looking for as a Tag object. You can also provide multiple
+        tags to chain queries. 
     - If you need to return _all_ matching tags, rather than the first match, set
         `multiple=True`.
     - Choose how to extract a value: set `attribute`, `flatten`, or `extract_soup_func`
@@ -271,29 +271,37 @@ class XML(Extractor):
         transform it, add a function for `transform`.
 
     Parameters:
-        tag: Tag to select. Can be:
-            - an XMLTag object
-            - a list of XMLTag objects, indicating a chain of descendants.
-            - `None`, to select the current head of the tree.
-        attribute: By default, the extractor will extract the text content of the tag.
-            Set this property to extract the value of an _attribute_ instead.
-        flatten: When extracting the text content of a tag, `flatten` determines whether
+        tags:
+            Tags to select. Each of these can be a `Tag` object, or a callable that
+            takes the document metadata as input and returns a `Tag`.
+            
+            Tags represent a query to select tags from current tag (e.g. the entry tag of
+            the document). If you provide multiple, they are chained: each Tag query is
+            applied to the results from the previous one.
+        attribute:
+            By default, the extractor will extract the text content of the tag. Set this
+            property to extract the value of an _attribute_ instead.
+        flatten:
+            When extracting the text content of a tag, `flatten` determines whether
             the contents of non-text children are flattened. If `False`, only the direct
-            text content of the tag is extracted. This parameter does nothing if
-            `attribute=True` is set.
-        toplevel: If `True`, the extractor will search from the toplevel tag of the XML
+            text content of the tag is extracted.
+            
+            This parameter does nothing if `attribute=True` is set.
+        toplevel:
+            If `True`, the extractor will search from the toplevel tag of the XML
             document, rather than the entry tag for the document.
-        multiple: If `False`, the extractor will extract the first matching element. If 
+        multiple:
+            If `False`, the extractor will extract the first matching element. If 
             `True`, it will extract a list of all matching elements.
-        external_file: This property can be set to look through a secondary XML file
-            (usually one containing metadata). It requires that the passed metadata have an
-            `'external_file'` key that specifies the path to the file. This parameter
-            specifies the toplevel tag and entry level tag for that file; if set, the
-            extractor will extract this field from the external file instead of the current
-            source file.
+        external_file:
+            If `True`, the extractor will look through a secondary XML file (usually one
+            containing metadata). It requires that the passed metadata have an
+            `'external_file'` key that specifies the path to the file.
+
+            Note: this option is not supported when this extractor is nested in another
+            extractor (like `Combined`).
         extract_soup_func: A function to extract a value directly from the soup element,
-            instead of using the content string or an attribute. Keep in mind
-            that the soup passed could be `None`.
+            instead of using the content string or an attribute.
             `attribute` and `flatten` will do nothing if this property is set.
         **kwargs: additional options to pass on to `Extractor`.
     '''

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -14,7 +14,7 @@ import traceback
 from typing import Any, Dict, Callable, List, Optional
 logger = logging.getLogger()
 
-from .utils import TagsInput, _resolve_tag
+from .xml_tag import TagsInput, _resolve_tag
 
 
 class Extractor(object):

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -314,7 +314,6 @@ class XML(Extractor):
                  flatten: bool = False,
                  toplevel: bool = False,
                  multiple: bool = False,
-                 sibling_tag: TagInput = None,
                  external_file: Dict = {
                      'xml_tag_toplevel': None,
                      'xml_tag_entry': None
@@ -330,7 +329,6 @@ class XML(Extractor):
         self.flatten = flatten
         self.toplevel = toplevel
         self.multiple = multiple
-        self.sibling_tag = sibling_tag
         self.external_file = external_file if external_file['xml_tag_toplevel'] else None
         self.transform_soup_func = transform_soup_func
         self.extract_soup_func = extract_soup_func

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -11,10 +11,10 @@ import html
 import re
 import logging
 import traceback
-from typing import Any, Dict, Callable, Union, List, Pattern, Optional
+from typing import Any, Dict, Callable, List, Optional
 logger = logging.getLogger()
 
-from .utils import XMLTag, TagSpecification, TagsInput
+from .utils import TagsInput, _resolve_tag
 
 
 class Extractor(object):
@@ -331,18 +331,14 @@ class XML(Extractor):
             tags = [tag]
 
         if len(tags) > 1:
-            tag = self._resolve_tag(tags[0], metadata)
+            tag = _resolve_tag(tags[0], metadata)
             for element in tag.find_in_soup(soup):
                 for result in self._select(tags[1:], element, metadata):
                     yield result
         elif len(tags) == 1:
-            tag = self._resolve_tag(tags[0], metadata)
+            tag = _resolve_tag(tags[0], metadata)
             for result in tag.find_in_soup(soup):
                 yield result
-
-    
-    def _resolve_tag(self, tag: TagSpecification, metadata: Dict) -> XMLTag:
-        return tag(metadata) if callable(tag) else tag
 
 
     def _apply(self, soup_top, soup_entry, *nargs, **kwargs):

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -359,7 +359,7 @@ class XML(Extractor):
                 if self.tag[i] == '.':
                     pass
                 else:
-                    soup = self.tag[i].find_in_soup(soup)
+                    soup = self.tag[i].find_next_in_soup(soup)
                 if not soup:
                     return None
             tag = self.tag[-1]
@@ -371,9 +371,9 @@ class XML(Extractor):
             return None
 
         if self.multiple:
-            return tag.find_all_in_soup(soup)
-        else:
             return tag.find_in_soup(soup)
+        else:
+            return tag.find_next_in_soup(soup)
     
     def _resolve_tag(self, tag: TagInput, metadata: Dict) -> Optional[XMLTag]:
         return tag(metadata) if callable(tag) else tag
@@ -393,7 +393,7 @@ class XML(Extractor):
         '''
         sibling_tag = self._resolve_tag(self.sibling_tag, metadata)
         if sibling_tag:
-            return sibling_tag.find_in_soup(soup).parent
+            return sibling_tag.find_next_in_soup(soup).parent
         
         return soup
 

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -265,9 +265,6 @@ class XML(Extractor):
         providing a list.
     - If you need to return _all_ matching tags, rather than the first match, set
         `multiple=True`.
-    - If needed, set `transform_soup_func` to further modify the matched tag. For
-        instance, you could use built-in parameters to select a tag, and then add a
-        `transform_soup_func` to select a child from it with a more complex condition.
     - Choose how to extract a value: set `attribute`, `flatten`, or `extract_soup_func`
         if needed.
     - The extracted value is a string, or the output of `extract_soup_func`. To further
@@ -294,10 +291,6 @@ class XML(Extractor):
             specifies the toplevel tag and entry level tag for that file; if set, the
             extractor will extract this field from the external file instead of the current
             source file.
-        transform_soup_func: A function to transform the soup directly after the tag is
-            selected, before further processing (attributes, flattening, etc) to extract
-            the value from it. Keep in mind that the soup passed could be `None` if no
-            matching tag is found.
         extract_soup_func: A function to extract a value directly from the soup element,
             instead of using the content string or an attribute. Keep in mind
             that the soup passed could be `None`.
@@ -318,7 +311,6 @@ class XML(Extractor):
                      'xml_tag_toplevel': None,
                      'xml_tag_entry': None
                  },
-                 transform_soup_func: Optional[Callable] = None,
                  extract_soup_func: Optional[Callable] = None,
                  *nargs,
                  **kwargs
@@ -330,7 +322,6 @@ class XML(Extractor):
         self.toplevel = toplevel
         self.multiple = multiple
         self.external_file = external_file if external_file['xml_tag_toplevel'] else None
-        self.transform_soup_func = transform_soup_func
         self.extract_soup_func = extract_soup_func
         super().__init__(*nargs, **kwargs)
 
@@ -376,13 +367,9 @@ class XML(Extractor):
         
         if self.multiple:
             results = list(results_generator)
-            if self.transform_soup_func:
-                results = map(self.transform_soup_func, results)
             return list(map(self._extract, results))
         else:
             result = next(results_generator, None)
-            if self.transform_soup_func:
-                result = self.transform_soup_func(result)
             return self._extract(result)
 
     def _extract(self, soup: Optional[bs4.PageElement]):

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -280,9 +280,6 @@ class XML(Extractor):
             - an XMLTag object
             - a list of XMLTag objects, indicating a chain of descendants.
             - `None`, to select the current head of the tree.
-        parent_level: If set, the extractor will ascend the tree before looking for the
-            indicated `tag`. Useful when you need to select information from a tag's
-            sibling or parent.
         attribute: By default, the extractor will extract the text content of the tag.
             Set this property to extract the value of an _attribute_ instead.
         flatten: When extracting the text content of a tag, `flatten` determines whether
@@ -323,7 +320,6 @@ class XML(Extractor):
 
     def __init__(self,
                  tag: Union[XMLTag, List[XMLTag], None],
-                 parent_level: Optional[int] = None,
                  attribute: Optional[str] = None,
                  flatten: bool = False,
                  toplevel: bool = False,
@@ -340,7 +336,6 @@ class XML(Extractor):
                  ):
 
         self.tag = tag
-        self.parent_level = parent_level
         self.attribute = attribute
         self.flatten = flatten
         self.toplevel = toplevel
@@ -357,12 +352,6 @@ class XML(Extractor):
         extractor.
         '''
 
-        if self.parent_level:
-            count = 0
-            while count < self.parent_level:
-                soup = soup.parent
-                count += 1
-
         # If the tag was a path, walk through it before continuing
         tag = self.tag
         if not tag:
@@ -371,9 +360,7 @@ class XML(Extractor):
             if len(tag) == 0:
                 return soup
             for i in range(0, len(self.tag)-1):
-                if self.tag[i] == '..':
-                    soup = soup.parent
-                elif self.tag[i] == '.':
+                if self.tag[i] == '.':
                     pass
                 else:
                     soup = self.tag[i].find_in_soup(soup)

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -302,14 +302,13 @@ class XML(Extractor):
             `'exact'`, which gives a string to match, or `'match'`, which gives the name of
             a metadata field against which to match the content. If this field has
             `external_file=True`, then `'match'` can also give the name of another field in
-            the reader, which as `external_file=False`.
+            the reader, which has `external_file=False`.
         external_file: This property can be set to look through a secondary XML file
             (usually one containing metadata). It requires that the passed metadata have an
             `'external_file'` key that specifies the path to the file. This parameter
             specifies the toplevel tag and entry level tag for that file; if set, the
             extractor will extract this field from the external file instead of the current
             source file.
-            The value for `entry_tag` is only used if the extractor does not have a `se
         transform_soup_func: A function to transform the soup directly after the tag is
             selected, before further processing (attributes, flattening, etc) to extract
             the value from it. Keep in mind that the soup passed could be `None` if no

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -14,7 +14,7 @@ import traceback
 from typing import Any, Dict, Callable, Union, List, Pattern, Optional
 logger = logging.getLogger()
 
-from .utils import XMLTag
+from .utils import XMLTag, TagSpecification, TagsInput
 
 
 class Extractor(object):
@@ -298,9 +298,6 @@ class XML(Extractor):
         **kwargs: additional options to pass on to `Extractor`.
     '''
 
-    TagInput = Union[XMLTag, Callable[[Dict], Optional[XMLTag]], None]
-    TagsInput = Union[TagInput, List[TagInput]]
-
     def __init__(self,
                  tag: TagsInput,
                  attribute: Optional[str] = None,
@@ -338,23 +335,16 @@ class XML(Extractor):
 
         if len(tags) > 1:
             tag = self._resolve_tag(tags[0], metadata)
-            if tag:
-                for element in tag.find_in_soup(soup):
-                    for result in self._select(tags[1:], element, metadata):
-                        yield result
-            else:
-                for result in self._select(tags[1:], soup, metadata):
+            for element in tag.find_in_soup(soup):
+                for result in self._select(tags[1:], element, metadata):
                     yield result
         elif len(tags) == 1:
             tag = self._resolve_tag(tags[0], metadata)
-            if tag:
-                for result in tag.find_in_soup(soup):
-                    yield result
-            else:
-                yield soup
+            for result in tag.find_in_soup(soup):
+                yield result
 
     
-    def _resolve_tag(self, tag: TagInput, metadata: Dict) -> Optional[XMLTag]:
+    def _resolve_tag(self, tag: TagSpecification, metadata: Dict) -> XMLTag:
         return tag(metadata) if callable(tag) else tag
 
 

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -304,10 +304,7 @@ class XML(Extractor):
                  flatten: bool = False,
                  toplevel: bool = False,
                  multiple: bool = False,
-                 external_file: Dict = {
-                     'xml_tag_toplevel': None,
-                     'xml_tag_entry': None
-                 },
+                 external_file: bool = False,
                  extract_soup_func: Optional[Callable] = None,
                  *nargs,
                  **kwargs
@@ -318,7 +315,7 @@ class XML(Extractor):
         self.flatten = flatten
         self.toplevel = toplevel
         self.multiple = multiple
-        self.external_file = external_file if external_file['xml_tag_toplevel'] else None
+        self.external_file = external_file
         self.extract_soup_func = extract_soup_func
         super().__init__(*nargs, **kwargs)
 

--- a/ianalyzer_readers/readers/csv.py
+++ b/ianalyzer_readers/readers/csv.py
@@ -71,7 +71,7 @@ class CSVReader(Reader):
 
         # make sure the field size is as big as the system permits
         csv.field_size_limit(sys.maxsize)
-        self._reject_extractors(extract.XML, extract.FilterAttribute)
+        self._reject_extractors(extract.XML)
 
         if isinstance(source, str):
             filename = source

--- a/ianalyzer_readers/readers/html.py
+++ b/ianalyzer_readers/readers/html.py
@@ -54,11 +54,11 @@ class HTMLReader(XMLReader):
         tag0 = self.tag_toplevel
         tag = self.tag_entry
 
-        bowl = tag0.find_in_soup(soup) if tag0 else soup
+        bowl = tag0.find_next_in_soup(soup) if tag0 else soup
 
         # if there is a entry level tag; with html this is not always the case
         if bowl and tag:
-            for i, spoon in enumerate(tag.find_all_in_soup(soup)):
+            for i, spoon in enumerate(tag.find_in_soup(soup)):
                 # yield
                 yield {
                     field.name: field.extractor.apply(

--- a/ianalyzer_readers/readers/html.py
+++ b/ianalyzer_readers/readers/html.py
@@ -55,12 +55,11 @@ class HTMLReader(XMLReader):
         tag0 = self.tag_toplevel
         tag = self.tag_entry
 
-        bowl = soup.find(tag0) if tag0 else soup
+        bowl = tag0.find_in_soup(soup) if tag0 else soup
 
-        # if there is a entry level tag, with html this is not always the case
+        # if there is a entry level tag; with html this is not always the case
         if bowl and tag:
-            # Note that this is non-recursive: will only find direct descendants of the top-level tag
-            for i, spoon in enumerate(bowl.find_all(tag)):
+            for i, spoon in enumerate(tag.find_all_in_soup(soup)):
                 # yield
                 yield {
                     field.name: field.extractor.apply(

--- a/ianalyzer_readers/readers/html.py
+++ b/ianalyzer_readers/readers/html.py
@@ -22,8 +22,7 @@ class HTMLReader(XMLReader):
     It is based on the XMLReader and supports the same options (`tag_toplevel` and
     `tag_entry`).
 
-    In addition to generic extractor classes, this reader supports the `XML` and
-    `FilterAttribute` extractors.
+    In addition to generic extractor classes, this reader supports the `XML` extractor.
     '''
 
     def source2dicts(self, source: Source) -> Iterable[Document]:

--- a/ianalyzer_readers/readers/xlsx.py
+++ b/ianalyzer_readers/readers/xlsx.py
@@ -62,7 +62,7 @@ class XLSXReader(Reader):
                 are based on the extractor of each field.
         '''
 
-        self._reject_extractors(extract.XML, extract.FilterAttribute)
+        self._reject_extractors(extract.XML)
 
         if isinstance(source, str):
             filename = source

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -105,7 +105,7 @@ class XMLReader(Reader):
         tag = self._get_tag_requirements(self.tag_entry, metadata)
         bowl = self._bowl_from_soup(soup, metadata=metadata)
         if bowl:
-            spoonfuls = tag.find_all_in_soup(bowl) if tag else [bowl]
+            spoonfuls = tag.find_in_soup(bowl) if tag else [bowl]
             for i, spoon in enumerate(spoonfuls):
                 regular_field_dict = {field.name: field.extractor.apply(
                     # The extractor is put to work by simply throwing at it
@@ -223,7 +223,7 @@ class XMLReader(Reader):
             toplevel_tag = self._get_tag_requirements(toplevel_tag, metadata)
 
         if toplevel_tag:
-            return toplevel_tag.find_in_soup(soup)
+            return toplevel_tag.find_next_in_soup(soup)
         else:
             return soup
 

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -10,7 +10,7 @@ from typing import Dict, Iterable, Tuple, List
 
 from .. import extract
 from .core import Reader, Source, Document, Field
-from ..xml_tag import CurrentTag, _resolve_tag, TagSpecification
+from ..xml_tag import CurrentTag, resolve_tag_specification, TagSpecification
 
 
 logger = logging.getLogger()
@@ -103,11 +103,11 @@ class XMLReader(Reader):
             field.name for field in self.fields if field.required]
 
         # iterate through entries
-        top_tag = _resolve_tag(self.tag_toplevel, metadata)
+        top_tag = resolve_tag_specification(self.tag_toplevel, metadata)
         bowl = top_tag.find_next_in_soup(soup)
 
         if bowl:
-            entry_tag = _resolve_tag(self.tag_entry, metadata)
+            entry_tag = resolve_tag_specification(self.tag_entry, metadata)
             spoonfuls = entry_tag.find_in_soup(bowl)
             for i, spoon in enumerate(spoonfuls):
                 # Extract fields from the soup
@@ -144,7 +144,7 @@ class XMLReader(Reader):
         return a dictionary with tags which were found in that metadata
         wrt to the current source.
         '''
-        tag = _resolve_tag(self.external_file_tag_toplevel, metadata)
+        tag = resolve_tag_specification(self.external_file_tag_toplevel, metadata)
         bowl = tag.find_next_in_soup(soup)
 
         if not bowl:

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -4,10 +4,9 @@ This module defines the XML Reader.
 Extraction is based on BeautifulSoup.
 '''
 
-import itertools
 import bs4
 import logging
-from typing import Union, Dict, Callable, Any, Iterable, Tuple, List
+from typing import Union, Dict, Callable, Iterable, Tuple, List
 
 from .. import extract
 from .core import Reader, Source, Document, Field
@@ -15,7 +14,7 @@ from ..utils import XMLTag, CurrentTag
 
 TagSpecification = Union[
     XMLTag,
-    Callable[[Any, Dict], XMLTag]
+    Callable[[Dict], XMLTag]
 ]
 
 logger = logging.getLogger()
@@ -40,9 +39,8 @@ class XMLReader(Reader):
     Can be:
 
     - An XMLTag
-    - A 
-    - A dictionary that gives the named arguments to soup.find_all()
-    - A bound method that takes the metadata of the document as input and outputs one of the above.
+    - A callable that takes the metadata of the document as input and returns an
+        XMLTag.
     '''
 
     tag_entry: TagSpecification = CurrentTag()
@@ -51,13 +49,22 @@ class XMLReader(Reader):
 
     Can be:
 
-    - None
-    - A string with the name of the tag
-    - A dictionary that gives the named arguments to soup.find_all()
-    - A bound method that takes the metadata of the document as input and outputs one of the above.
+    - An XMLTag
+    - A callable that takes the metadata of the document as input and returns an
+        XMLTag
     '''
 
     external_file_tag_toplevel: TagSpecification = CurrentTag()
+    '''
+    The toplevel tag in external files (if you are using that functionality)
+
+    Can be:
+
+    - An XMLTag
+    - A callable that takes the metadata of the document as input and returns an
+        XMLTag. The metadata dictionary includes the values of "regular" fields for
+        the document.
+    '''
 
     def source2dicts(self, source: Source) -> Iterable[Document]:
         '''
@@ -140,7 +147,6 @@ class XMLReader(Reader):
         Get the requirements for a tag given the specification and metadata.
 
         The specification can be:
-        - None
         - An `XMLTag` object
         - A callable that takes an `XMLReader` instance and a dictionary with metadata for the
             file, and returns one of the above.

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -11,14 +11,14 @@ from typing import Union, Dict, Callable, Any, Iterable, Tuple
 
 from .. import extract
 from .core import Reader, Source, Document
-from .. import utils
+from ..utils import XMLTag
 
 logger = logging.getLogger()
 
 TagSpecification = Union[
     None,
-    utils.XMLTag,
-    Callable[[Any, Dict], Union[None, utils.XMLTag]]
+    XMLTag,
+    Callable[[Any, Dict], Union[None, XMLTag]]
 ]
 '''
 A specification for an XML tag used in the `XMLReader`.
@@ -102,10 +102,11 @@ class XMLReader(Reader):
         required_fields = [
             field.name for field in self.fields if field.required]
         # Extract fields from the soup
+
         tag = self._get_tag_requirements(self.tag_entry, metadata)
         bowl = self._bowl_from_soup(soup, metadata=metadata)
         if bowl:
-            spoonfuls = bowl.find_all(**tag) if tag else [bowl]
+            spoonfuls = tag.find_all_in_soup(bowl) if tag else [bowl]
             for i, spoon in enumerate(spoonfuls):
                 regular_field_dict = {field.name: field.extractor.apply(
                     # The extractor is put to work by simply throwing at it
@@ -131,34 +132,28 @@ class XMLReader(Reader):
                     yield full_dict
         else:
             logger.warning(
-                'Top-level tag not found in `{}`'.format(filename))
+                'Top-level tag not found in `{}`'.format(source))
 
-    def _get_tag_requirements(self, specification, metadata):
+    def _get_tag_requirements(self, specification: TagSpecification, metadata: Dict) -> Union[None, XMLTag]:
         '''
         Get the requirements for a tag given the specification and metadata.
 
         The specification can be:
         - None
-        - A string with the name of the tag
-        - A dict with the named arguments to soup.find() / soup.find_all()
-        - A callable that takes the document metadata as input and outputs one of the above.
+        - An `XMLTag` object
+        - A callable that takes an `XMLReader` instance and a dictionary with metadata for the
+            file, and returns one of the above.
 
-        Output is either None or a dict with the arguments for soup.find() / soup.find_all()
+        Returns:
+            either `None` or an `XMLTag` object
+            
+        If the specification is a callable, this method calls it.
         '''
 
         if callable(specification):
-            condition = specification(metadata)
+            return specification(metadata)
         else:
-            condition = specification
-
-        if condition is None:
-            return None
-        elif type(condition) == str:
-            return {'name': condition}
-        elif type(condition) == dict:
-            return condition
-        else:
-            raise TypeError('Tag must be a string or dict')
+            return specification
 
     def _external_source2dict(self, soup, external_fields, metadata):
         '''
@@ -227,7 +222,11 @@ class XMLReader(Reader):
         '''
         return bs4.BeautifulSoup(data, 'lxml-xml')
 
-    def _bowl_from_soup(self, soup, toplevel_tag=None, entry_tag=None, metadata = {}):
+    def _bowl_from_soup(self,
+            soup,
+            toplevel_tag: TagSpecification = None,
+            metadata: Dict = {}
+        ):
         '''
         Returns bowl (subset of soup) of soup object. Bowl contains everything within the toplevel tag.
         If no such tag is present, it contains the entire soup.
@@ -237,53 +236,8 @@ class XMLReader(Reader):
         else:
             toplevel_tag = self._get_tag_requirements(toplevel_tag, metadata)
 
-        return soup.find(**toplevel_tag) if toplevel_tag else soup
-
-    def _metadata_from_xml(self, filename, tags):
-        '''
-        Given a filename of an xml with metadata, and a range of tags to extract,
-        return a dictionary of all the contents of the requested tags.
-        A tag can either be a string, or a dictionary:
-        {
-            "tag": "tag_to_extract",
-            "attribute": attribute to additionally filter on, optional
-            "save_as": key to use in output dictionary, optional
-        }
-        '''
-        out_dict = {}
-        soup = self._soup_from_xml(filename)
-        for tag in tags:
-            if isinstance(tag, str):
-                tag_info = soup.find(tag)
-                if not tag_info:
-                    continue
-                out_dict[tag] = tag_info.text
-            else:
-                candidates = soup.find_all(tag['tag'])
-                if 'attribute' in tag:
-                    right_tag = next((candidate for candidate in candidates if
-                                      candidate.attrs == tag['attribute']), None)
-                elif 'list' in tag:
-                    if 'subtag' in tag:
-                        right_tag = [candidate.find(
-                            tag['subtag']) for candidate in candidates]
-                    else:
-                        right_tag = candidates
-                elif 'subtag' in tag:
-                    right_tag = next((candidate.find(tag['subtag']) for candidate in candidates if
-                                      candidate.find(tag['subtag'])), None)
-                else:
-                    right_tag = next((candidate for candidate in candidates if
-                                      candidate.attrs == {}), None)
-                if not right_tag:
-                    continue
-                if 'save_as' in tag:
-                    out_tag = tag['save_as']
-                else:
-                    out_tag = tag['tag']
-                if 'list' in tag:
-                    out_dict[out_tag] = [t.text for t in right_tag]
-                else:
-                    out_dict[out_tag] = right_tag.text
-        return out_dict
+        if toplevel_tag:
+            return toplevel_tag.find_in_soup(soup)
+        else:
+            return soup
 

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -165,23 +165,10 @@ class XMLReader(Reader):
         for field in external_fields:
             bowl = self._bowl_from_soup(
                 soup, field.extractor.external_file['xml_tag_toplevel'])
-            spoon = None
-            if field.extractor.secondary_tag:
-                # find a specific subtree in the xml tree identified by matching a secondary tag
-                try:
-                    spoon = bowl.find(
-                        field.extractor.secondary_tag['tag'],
-                        string=metadata[field.extractor.secondary_tag['match']]).parent
-                except:
-                    logging.debug('tag {} not found in metadata'.format(
-                        field.extractor.secondary_tag
-                    ))
-            if not spoon:
-                spoon = field.extractor.external_file['xml_tag_entry']
             if bowl:
                 external_dict[field.name] = field.extractor.apply(
                     soup_top=bowl,
-                    soup_entry=spoon,
+                    soup_entry=bowl,
                     metadata=metadata
                 )
             else:

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -19,13 +19,22 @@ class XMLReader(Reader):
     '''
     A base class for Readers that extract data from XML files.
 
-    The built-in functionality of the XML reader is quite versatile, and can be further expanded by
-    adding custom functions to XML extractors that interact directly with BeautifulSoup nodes.
+    The built-in functionality of the XML reader is quite versatile, and can be further
+    expanded by adding custom Tag classes or extraction functions that interact directly with
+    BeautifulSoup nodes.
 
-    The Reader is suitable for datasets where each file should be extracted as a single document, or
-    ones where each file contains multiple documents.
+    The Reader is suitable for datasets where each file should be extracted as a single
+    document, or ones where each file contains multiple documents.
 
     In addition to generic extractor classes, this reader supports the `XML` extractor.
+
+    Attributes:
+        tag_toplevel: the top-level tag to search from in source documents.
+        tag_entry: the tag that corresponds to a single document entry in source
+            documents.
+        external_file_tag_toplevel: the top-level tag to search from in external
+            documents (if that functionality is used)
+
     '''
 
     tag_toplevel: TagSpecification = CurrentTag()
@@ -52,7 +61,7 @@ class XMLReader(Reader):
 
     external_file_tag_toplevel: TagSpecification = CurrentTag()
     '''
-    The toplevel tag in external files (if you are using that functionality)
+    The toplevel tag in external files (if you are using that functionality).
 
     Can be:
 

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -41,8 +41,7 @@ class XMLReader(Reader):
     The Reader is suitable for datasets where each file should be extracted as a single document, or
     ones where each file contains multiple documents.
 
-    In addition to generic extractor classes, this reader supports the `XML` and
-    `FilterAttribute` extractors.
+    In addition to generic extractor classes, this reader supports the `XML` extractor.
     '''
 
     tag_toplevel: TagSpecification = None

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -4,20 +4,21 @@ This module defines the XML Reader.
 Extraction is based on BeautifulSoup.
 '''
 
-from .. import extract
-from .core import Reader, Source, Document
 import itertools
 import bs4
 import logging
 from typing import Union, Dict, Callable, Any, Iterable
 
+from .. import extract
+from .core import Reader, Source, Document
+from .. import utils
+
 logger = logging.getLogger()
 
 TagSpecification = Union[
     None,
-    str,
-    Dict[str, Any],
-    Callable[[Any, Dict], Union[None, str, Dict[str, Any]]]
+    utils.XMLTag,
+    Callable[[Any, Dict], Union[None, utils.XMLTag]]
 ]
 '''
 A specification for an XML tag used in the `XMLReader`.
@@ -25,11 +26,9 @@ A specification for an XML tag used in the `XMLReader`.
 These can be:
 
 - None
-- a string with the name of the tag
-- a dictionary with the named arguments that should be passed to the `find()` / `find_all()`
-    method of a BeautifulSoup node.
-- A callable that takes an `XMLReader` instance and a dictionary with file metadata, and
-    returns any of the above.
+- An `XMLTag` object
+- A callable that takes an `XMLReader` instance and a dictionary with metadata for the
+    file, and returns one of the above.
 '''
 
 class XMLReader(Reader):

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -10,7 +10,7 @@ from typing import Dict, Iterable, Tuple, List
 
 from .. import extract
 from .core import Reader, Source, Document, Field
-from ..utils import XMLTag, CurrentTag, _resolve_tag, TagSpecification
+from ..xml_tag import CurrentTag, _resolve_tag, TagSpecification
 
 
 logger = logging.getLogger()

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -73,7 +73,7 @@ class XMLReader(Reader):
         # Make sure that extractors are sensible
         self._reject_extractors(extract.CSV)
 
-        soup, metadata = self._soup_and_metadata_from_source(source)
+        filename, soup, metadata = self._filename_soup_and_metadata_from_source(source)
 
         # extract information from external xml files first, if applicable
         if metadata and 'external_file' in metadata:
@@ -120,7 +120,7 @@ class XMLReader(Reader):
                     yield full_dict
         else:
             logger.warning(
-                'Top-level tag not found in `{}`'.format(source))
+                'Top-level tag not found in `{}`'.format(filename))
 
     def _resolve_tag(self, specification: TagSpecification, metadata: Dict) -> XMLTag:
         '''
@@ -161,24 +161,23 @@ class XMLReader(Reader):
                 )
             else:
                 logger.warning(
-                    'Top-level tag not found in `{}`'.format(bowl))
+                    'Top-level tag not found in `{}`'.format(metadata['external_file']))
         return external_dict
 
-    def _soup_and_metadata_from_source(self, source: Source) -> Tuple[bs4.BeautifulSoup, Dict]:
-        metadata = {}
+    def _filename_soup_and_metadata_from_source(self, source: Source) -> Tuple[str, bs4.BeautifulSoup, Dict]:
         if isinstance(source, str):
-            # no metadata
             filename = source
             soup = self._soup_from_xml(filename)
+            metadata = {}
         elif isinstance(source, bytes):
             soup = self._soup_from_data(source)
-            filename = soup.find('RecordID')
+            filename = None
+            metadata = {}
         else:
             filename = source[0]
             soup = self._soup_from_xml(filename)
             metadata = source[1] or None
-            soup = self._soup_from_xml(filename)
-        return soup, metadata
+        return filename, soup, metadata
 
     def _soup_from_xml(self, filename):
         '''

--- a/ianalyzer_readers/utils.py
+++ b/ianalyzer_readers/utils.py
@@ -95,3 +95,9 @@ class TransformTag(XMLTag):
 
 TagSpecification = Union[XMLTag, Callable[[Dict], XMLTag]]
 TagsInput = Union[TagSpecification, List[TagSpecification]]
+
+def _resolve_tag(tag: TagSpecification, metadata: Dict) -> XMLTag:
+    if callable(tag):
+        return tag(metadata)
+    else:
+        return tag

--- a/ianalyzer_readers/utils.py
+++ b/ianalyzer_readers/utils.py
@@ -13,14 +13,41 @@ class XMLTag:
         self.args = args
         self.kwargs = kwargs
     
-    def find_in_soup(self, soup: bs4.BeautifulSoup):
+    def find_in_soup(self, soup: bs4.element.Tag):
         '''
         Search for this tag using `soup.find()`
         '''
         return soup.find(*self.args, **self.kwargs)
     
-    def find_all_in_soup(self, soup: bs4.BeautifulSoup):
+    def find_all_in_soup(self, soup: bs4.element.Tag):
         '''
         Search for this tag using `soup.find_all()`
         '''
         return soup.find_all(*self.args, **self.kwargs)
+
+class ParentTag(XMLTag):
+    '''
+    An XMLTag that will select the parent tag.
+    '''
+
+    def __init__(self, level=1):
+        self.level = level
+
+    def find_in_soup(self, soup: bs4.element.Tag):
+        count = 0
+        while count < self.level:
+            soup = soup.parent if soup else None
+            count += 1
+
+        return soup
+    
+    def find_all_in_soup(self, soup: bs4.element.Tag):
+        parent = self.find_in_soup(soup)
+        return [parent] if parent else []
+
+
+class AncestorTag(XMLTag):
+    '''
+    An XMLTag that will search though a tag's ancestors, rather than
+    its children.
+    '''

--- a/ianalyzer_readers/utils.py
+++ b/ianalyzer_readers/utils.py
@@ -1,0 +1,26 @@
+import bs4
+
+class XMLTag:
+    '''
+    Describes a tag in an XML tree.
+
+    Parameters:
+        *args: positional arguments to pass on to BeautifulSoup.find() (and similar methods)
+        **kwargs: named arguments to pass on to BeautifulSoup.find() (and similar methods)
+    '''
+    
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+    
+    def find_in_soup(self, soup: bs4.BeautifulSoup):
+        '''
+        Search for this tag using `soup.find()`
+        '''
+        return soup.find(*self.args, **self.kwargs)
+    
+    def find_all_in_soup(self, soup: bs4.BeautifulSoup):
+        '''
+        Search for this tag using `soup.find_all()`
+        '''
+        return soup.find_all(*self.args, **self.kwargs)

--- a/ianalyzer_readers/utils.py
+++ b/ianalyzer_readers/utils.py
@@ -27,13 +27,13 @@ class XMLTag:
 
 class ParentTag(XMLTag):
     '''
-    An XMLTag that will select the parent tag.
+    An XMLTag that will select a parent tag based on a fixed level.
     '''
 
     def __init__(self, level=1):
         self.level = level
 
-    def find_in_soup(self, soup: bs4.element.Tag):
+    def find_in_soup(self, soup: bs4.element.PageElement):
         count = 0
         while count < self.level:
             soup = soup.parent if soup else None
@@ -41,13 +41,19 @@ class ParentTag(XMLTag):
 
         return soup
     
-    def find_all_in_soup(self, soup: bs4.element.Tag):
+    def find_all_in_soup(self, soup: bs4.element.PageElement):
         parent = self.find_in_soup(soup)
         return [parent] if parent else []
 
 
-class AncestorTag(XMLTag):
+class FindParentTag(XMLTag):
     '''
-    An XMLTag that will search though a tag's ancestors, rather than
-    its children.
+    An XMLTag that will find a parent tag based on query arguments.
     '''
+
+    def find_in_soup(self, soup: bs4.element.PageElement):
+        return soup.find_parent(*self.args, **self.kwargs)
+    
+    def find_all_in_soup(self, soup: bs4.Tag):
+        return soup.find_parents(*self.args, **self.kwargs)
+

--- a/ianalyzer_readers/utils.py
+++ b/ianalyzer_readers/utils.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional, Callable, Union
+from typing import Iterable, Optional, Callable, Union, Dict, List
 import bs4
 
 class XMLTag:
@@ -92,3 +92,6 @@ class TransformTag(XMLTag):
             return result
         return [result]
     
+
+TagSpecification = Union[XMLTag, Callable[[Dict], XMLTag]]
+TagsInput = Union[TagSpecification, List[TagSpecification]]

--- a/ianalyzer_readers/utils.py
+++ b/ianalyzer_readers/utils.py
@@ -13,13 +13,13 @@ class XMLTag:
         self.args = args
         self.kwargs = kwargs
     
-    def find_in_soup(self, soup: bs4.element.Tag):
+    def find_in_soup(self, soup: bs4.element.PageElement):
         '''
         Search for this tag using `soup.find()`
         '''
         return soup.find(*self.args, **self.kwargs)
     
-    def find_all_in_soup(self, soup: bs4.element.Tag):
+    def find_all_in_soup(self, soup: bs4.element.PageElement):
         '''
         Search for this tag using `soup.find_all()`
         '''
@@ -57,3 +57,16 @@ class FindParentTag(XMLTag):
     def find_all_in_soup(self, soup: bs4.Tag):
         return soup.find_parents(*self.args, **self.kwargs)
 
+
+class SiblingTag(XMLTag):
+    '''
+    An XMLTag that will look in an element's siblings.
+    '''
+
+    def find_in_soup(self, soup: bs4.element.PageElement):
+        return soup.find_next_sibling(*self.args, **self.kwargs) or \
+            soup.find_previous_sibling(*self.args, *self.kwargs)
+
+    def find_all_in_soup(self, soup: bs4.PageElement):
+        return list(soup.find_next_siblings(*self.args, **self.kwargs)) + \
+            list(soup.find_previous_siblings(*self.args, **self.kwargs))

--- a/ianalyzer_readers/xml_tag.py
+++ b/ianalyzer_readers/xml_tag.py
@@ -146,6 +146,55 @@ class SiblingTag(Tag):
         for tag in soup.find_previous_siblings(*self.args, **self.kwargs):
             yield tag
 
+class PreviousSiblingTag(Tag):
+    '''
+    A Tag that will look in an element's previous siblings.
+
+    Parameters:
+        *args: positional arguments to pass on to `soup.find_previous_siblings()`
+        **kwargs: named arguments to pass on to `soup.find_previous_siblings()`
+    '''
+
+    def find_in_soup(self, soup: bs4.PageElement):
+        return soup.find_previous_siblings(*self.args, **self.kwargs)
+
+class NextSiblingTag(Tag):
+    '''
+    A Tag that will look in an element's next siblings.
+
+    Parameters:
+        *args: positional arguments to pass on to `soup.find_next_siblings()`
+        **kwargs: named arguments to pass on to `soup.find_next_siblings()`
+    '''
+
+    def find_in_soup(self, soup: bs4.PageElement):
+        return soup.find_next_siblings(*self.args, **self.kwargs)
+    
+class PreviousTag(Tag):
+    '''
+    A Tag that will look in an element's previous siblings.
+
+    Parameters:
+        *args: positional arguments to pass on to `soup.find_all_previous()`
+        **kwargs: named arguments to pass on to `soup.find_all_previous()`
+    '''
+
+    def find_in_soup(self, soup: bs4.PageElement):
+        return soup.find_all_previous(*self.args, **self.kwargs)
+    
+class NextTag(Tag):
+    '''
+    A Tag that will look in an element's previous siblings.
+
+    Parameters:
+        *args: positional arguments to pass on to `soup.find_all_next()`
+        **kwargs: named arguments to pass on to `soup.find_all_next()`
+    '''
+
+    def find_in_soup(self, soup: bs4.PageElement):
+        return soup.find_all_next(*self.args, **self.kwargs)
+
+
 class TransformTag(Tag):
     '''
     A Tag that will perform a transformation function.

--- a/ianalyzer_readers/xml_tag.py
+++ b/ianalyzer_readers/xml_tag.py
@@ -1,7 +1,7 @@
 from typing import Iterable, Optional, Callable, Union, Dict, List
 import bs4
 
-class XMLTag:
+class Tag:
     '''
     Describes a tag in an XML tree.
 
@@ -21,7 +21,7 @@ class XMLTag:
         return soup.find_all(*self.args, **self.kwargs)
 
 
-class CurrentTag(XMLTag):
+class CurrentTag(Tag):
     '''
     An XMLTag that will return the current tag.
     '''
@@ -33,7 +33,7 @@ class CurrentTag(XMLTag):
         return [soup]
 
 
-class ParentTag(XMLTag):
+class ParentTag(Tag):
     '''
     An XMLTag that will select a parent tag based on a fixed level.
     '''
@@ -49,7 +49,7 @@ class ParentTag(XMLTag):
         return [soup]
 
 
-class FindParentTag(XMLTag):
+class FindParentTag(Tag):
     '''
     An XMLTag that will find a parent tag based on query arguments.
     '''
@@ -58,7 +58,7 @@ class FindParentTag(XMLTag):
         return soup.find_parents(*self.args, **self.kwargs)
     
 
-class SiblingTag(XMLTag):
+class SiblingTag(Tag):
     '''
     An XMLTag that will look in an element's siblings.
     '''
@@ -70,7 +70,7 @@ class SiblingTag(XMLTag):
         for tag in soup.find_previous_siblings(*self.args, **self.kwargs):
             yield tag
 
-class TransformTag(XMLTag):
+class TransformTag(Tag):
     '''
     An XMLTag that will perform a transformation function.
 
@@ -93,10 +93,10 @@ class TransformTag(XMLTag):
         return [result]
     
 
-TagSpecification = Union[XMLTag, Callable[[Dict], XMLTag]]
+TagSpecification = Union[Tag, Callable[[Dict], Tag]]
 TagsInput = Union[TagSpecification, List[TagSpecification]]
 
-def _resolve_tag(tag: TagSpecification, metadata: Dict) -> XMLTag:
+def _resolve_tag(tag: TagSpecification, metadata: Dict) -> Tag:
     if callable(tag):
         return tag(metadata)
     else:

--- a/ianalyzer_readers/xml_tag.py
+++ b/ianalyzer_readers/xml_tag.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional, Callable, Union, Dict, List
+from typing import Iterable, Optional, Callable, Union, Dict
 import bs4
 
 class Tag:
@@ -91,12 +91,11 @@ class TransformTag(Tag):
         if self.returns_multiple:
             return result
         return [result]
-    
+
 
 TagSpecification = Union[Tag, Callable[[Dict], Tag]]
-TagsInput = Union[TagSpecification, List[TagSpecification]]
 
-def _resolve_tag(tag: TagSpecification, metadata: Dict) -> Tag:
+def resolve_tag_specification(tag: TagSpecification, metadata: Dict) -> Tag:
     if callable(tag):
         return tag(metadata)
     else:

--- a/ianalyzer_readers/xml_tag.py
+++ b/ianalyzer_readers/xml_tag.py
@@ -1,29 +1,84 @@
-from typing import Iterable, Optional, Callable, Union, Dict
+'''
+This module defines the `Tag` class (and various subclasses).
+
+This class is used in the `XML` extractor to read XML/HTML documents.
+
+Each `Tag` describes a query for one or more XML tags based on their
+characteristics. It implements a method `find_in_soup` that takes an
+element as input and iterates over matching tags.
+'''
+
+from typing import Iterable, Optional, Callable, Union, Dict, Any
 import bs4
+
+
 
 class Tag:
     '''
-    Describes a tag in an XML tree.
+    Describes a query for a tag in an XML tree.
 
+    This should be used as the base class for all other tags, which can override
+    the `__init__()` and `find_in_soup()` methods.
+
+    `Tag` is the most straightforward case: all arguments passed in the constructor
+    are passed on as-is to the `find_all()` method of the BeautifulSoup element, searching
+    descendants of the input tag.
+
+    See https://www.crummy.com/software/BeautifulSoup/bs4/doc/#kinds-of-filters for
+    different ways of searching. This includes searching by:
+    - a tag name (possibly as a regular expression)
+    - attributes of the tag
+    - the string content of the tag
+    - a function
+
+    Note that `find_all()` also supports 
+    
     Parameters:
-        *args: positional arguments to pass on to BeautifulSoup.find() (and similar methods)
-        **kwargs: named arguments to pass on to BeautifulSoup.find() (and similar methods)
+        *args: positional arguments to pass on to `soup.find_all()`
+        **kwargs: named arguments to pass on to `soup.find_all()`
     '''
     
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         self.args = args
         self.kwargs = kwargs
     
-    def find_next_in_soup(self, soup: bs4.element.PageElement) -> Optional[bs4.PageElement]:
+    def find_next_in_soup(self, soup: bs4.PageElement) -> Optional[bs4.PageElement]:
+        '''
+        Find the first match for the tag, if any.
+
+        Parameters:
+            soup: The element to search from.
+
+        Returns:
+            The first matching tag. Returns `None` if there is no match.
+        '''
         return next((tag for tag in self.find_in_soup(soup)), None)
 
-    def find_in_soup(self, soup: bs4.element.PageElement) -> Iterable[bs4.PageElement]:
+    def find_in_soup(self, soup: bs4.PageElement) -> Iterable[bs4.PageElement]:
+        '''
+        Find all results for this tag.
+
+        Parameters:
+            soup: The element to search from.
+
+        Returns:
+            An iterable of matching tags. Note that is is not guaranteed that the iterable
+                contains any elements.
+        
+        When subclassing Tag, you will usually want to replace this method. The result
+        must be an iterable. (If only one result makes sense, it's an iterable with one
+        element.) If the tag may find multiple matches, it's recommended that this method
+        returns a generator or a `bs4.ResultSet` rather than collecting all results up
+        front.
+        '''
         return soup.find_all(*self.args, **self.kwargs)
 
 
 class CurrentTag(Tag):
     '''
-    An XMLTag that will return the current tag.
+    A Tag query that will return the current tag.
+
+    Primarily useful as a default option.
     '''
 
     def __init__(self):
@@ -35,10 +90,16 @@ class CurrentTag(Tag):
 
 class ParentTag(Tag):
     '''
-    An XMLTag that will select a parent tag based on a fixed level.
+    A Tag that will select a parent tag based on a fixed level.
+
+    For example, `ParentTag(2)` will always go up two steps in the tree
+    and return that tag.
+
+    Parameters:
+        level: the number of steps to move up the tree.
     '''
 
-    def __init__(self, level=1):
+    def __init__(self, level: int = 1):
         self.level = level
 
     def find_in_soup(self, soup: bs4.PageElement):
@@ -51,7 +112,16 @@ class ParentTag(Tag):
 
 class FindParentTag(Tag):
     '''
-    An XMLTag that will find a parent tag based on query arguments.
+    A Tag that will find a parent tag based on query arguments.
+
+    Unlike ParentTag, this searches for a tag with a query.
+
+    For example, `ParentTag('foo')` will search for a `<foo>` ancestor
+    of the current tag.
+
+    Parameters:
+        *args: positional arguments to pass on to `soup.find_parents()`
+        **kwargs: named arguments to pass on to `soup.find_parents()`
     '''
 
     def find_in_soup(self, soup: bs4.PageElement):
@@ -60,7 +130,13 @@ class FindParentTag(Tag):
 
 class SiblingTag(Tag):
     '''
-    An XMLTag that will look in an element's siblings.
+    A Tag that will look in an element's siblings.
+
+    Parameters:
+        *args: positional arguments to pass on to `soup.find_previous_siblings()`
+            and `soup.find_next_siblings()`
+        **kwargs: named arguments to pass on to `soup.find_previous_siblings()`
+            and `soup.find_next_siblings()`
     '''
 
     def find_in_soup(self, soup: bs4.PageElement):
@@ -72,25 +148,24 @@ class SiblingTag(Tag):
 
 class TransformTag(Tag):
     '''
-    An XMLTag that will perform a transformation function.
+    A Tag that will perform a transformation function.
+
+    This Tag allows you to run arbitrary code to move to anywhere in the XML tree.
 
     Parameters:
-        transform: a function to transform
+        transform: a function that takes an XML element as input and returns an
+            iterable of XML elements. (Note that you can return an iterable of
+            one, or an empty iterable, if you don't have multiple results.)
     '''
 
     def __init__(
             self,
-            transform: Callable[[bs4.PageElement], Union[bs4.PageElement, Iterable[bs4.PageElement], None]],
-            returns_multiple=False
+            transform: Callable[[bs4.PageElement], Iterable[bs4.PageElement]],
         ):
         self.transform = transform
-        self.returns_multiple = returns_multiple
     
-    def find_in_soup(self, soup: bs4.PageElement):
-        result = self.transform(soup)
-        if self.returns_multiple:
-            return result
-        return [result]
+    def find_in_soup(self, soup: bs4.PageElement) -> Iterable[bs4.PageElement]:
+        return self.transform(soup)
 
 
 TagSpecification = Union[Tag, Callable[[Dict], Tag]]

--- a/tests/html_reader.py
+++ b/tests/html_reader.py
@@ -3,7 +3,7 @@ import os
 from ianalyzer_readers.readers.html import HTMLReader
 from ianalyzer_readers.readers.core import Field
 from ianalyzer_readers.extract import XML
-from ianalyzer_readers.utils import XMLTag, CurrentTag
+from ianalyzer_readers.xml_tag import Tag, CurrentTag
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -14,8 +14,8 @@ class HamletHTMLReader(HTMLReader):
 
     data_directory = os.path.join(here, 'html_example')
 
-    tag_toplevel = XMLTag('body')
-    tag_entry = XMLTag('p')
+    tag_toplevel = Tag('body')
+    tag_entry = Tag('p')
 
     def sources(self, **kwargs):
         for filename in os.listdir(self.data_directory):
@@ -26,11 +26,11 @@ class HamletHTMLReader(HTMLReader):
 
     title = Field(
         'title',
-        XML(XMLTag('h1'), toplevel=True)
+        XML(Tag('h1'), toplevel=True)
     )
     character = Field(
         'character',
-        XML(XMLTag('b'))
+        XML(Tag('b'))
     )
     lines = Field(
         'lines',

--- a/tests/html_reader.py
+++ b/tests/html_reader.py
@@ -3,7 +3,7 @@ import os
 from ianalyzer_readers.readers.html import HTMLReader
 from ianalyzer_readers.readers.core import Field
 from ianalyzer_readers.extract import XML
-from ianalyzer_readers.utils import XMLTag
+from ianalyzer_readers.utils import XMLTag, CurrentTag
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -34,7 +34,7 @@ class HamletHTMLReader(HTMLReader):
     )
     lines = Field(
         'lines',
-        XML(None, flatten=True),
+        XML(CurrentTag(), flatten=True),
     )
 
     fields = [title, character, lines]

--- a/tests/html_reader.py
+++ b/tests/html_reader.py
@@ -3,6 +3,7 @@ import os
 from ianalyzer_readers.readers.html import HTMLReader
 from ianalyzer_readers.readers.core import Field
 from ianalyzer_readers.extract import XML
+from ianalyzer_readers.utils import XMLTag
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -13,8 +14,8 @@ class HamletHTMLReader(HTMLReader):
 
     data_directory = os.path.join(here, 'html_example')
 
-    tag_toplevel = 'body'
-    tag_entry = 'p'
+    tag_toplevel = XMLTag('body')
+    tag_entry = XMLTag('p')
 
     def sources(self, **kwargs):
         for filename in os.listdir(self.data_directory):
@@ -25,11 +26,11 @@ class HamletHTMLReader(HTMLReader):
 
     title = Field(
         'title',
-        XML('h1', toplevel=True)
+        XML(XMLTag('h1'), toplevel=True)
     )
     character = Field(
         'character',
-        XML('b')
+        XML(XMLTag('b'))
     )
     lines = Field(
         'lines',

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -202,7 +202,7 @@ def test_xml_tag_chain_exhaustive(tmpdir):
 
 
 def test_xml_transform_tag(tmpdir):
-    find_location = lambda soup: soup.find_previous_sibling('location')
+    find_location = lambda soup: [soup.find_previous_sibling('location')]
     extractor = XML(TransformTag(find_location))
     reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'A more remote part of the Castle.')

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -291,7 +291,10 @@ def test_xml_external_file(tmpdir):
             Field(
                 name='author',
                 extractor=XML(
-                    XMLTag('author'),
+                    [
+                        lambda metadata: XMLTag('title', string=metadata['title']),
+                        SiblingTag('author')
+                    ],
                     sibling_tag = lambda metadata: XMLTag('title', string=metadata['title']),
                     external_file={'xml_tag_toplevel': XMLTag('bibliography'), 'xml_tag_entry': None}
                 )

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -4,7 +4,7 @@ import re
 from ianalyzer_readers.readers.xml import XMLReader
 from ianalyzer_readers.extract import XML
 from ianalyzer_readers.readers.core import Field
-from ianalyzer_readers.utils import XMLTag, ParentTag, FindParentTag
+from ianalyzer_readers.utils import XMLTag, ParentTag, FindParentTag, SiblingTag
 
 
 def make_test_reader(extractor, toplevel_tag, entry_tag, doc, tmpdir):
@@ -233,12 +233,17 @@ doc_longer = '''
 
 
 def test_xml_sibling_tag(tmpdir):
-    extractor = XML(
-        XMLTag('l'),
-        sibling_tag=XMLTag('character', string='GHOST')
-    )
+    extractor = XML(SiblingTag('character'))
+    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('l'), doc_longer, tmpdir)
+    assert_extractor_output(reader, 'HAMLET')
+
+    extractor = XML([
+        XMLTag('character', string='GHOST'),
+        SiblingTag('l')
+    ])
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_longer, tmpdir)
     assert_extractor_output(reader, 'Mark me.')
+
 
 doc_with_title = '''
 <?xml version="1.0" encoding="UTF-8"?>
@@ -250,6 +255,7 @@ doc_with_title = '''
     </lines>
 </play>
 '''
+
 
 external_doc = '''
 <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -4,7 +4,7 @@ import re
 from ianalyzer_readers.readers.xml import XMLReader
 from ianalyzer_readers.extract import XML
 from ianalyzer_readers.readers.core import Field
-from ianalyzer_readers.utils import XMLTag, ParentTag
+from ianalyzer_readers.utils import XMLTag, ParentTag, FindParentTag
 
 
 def make_test_reader(extractor, toplevel_tag, entry_tag, doc, tmpdir):
@@ -150,6 +150,16 @@ def test_xml_parent_tag(tmpdir):
     extractor = XML(ParentTag(2), attribute='n')
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'I')
+
+
+def test_xml_find_parent_tag(tmpdir):
+    extractor = XML(FindParentTag('act'), attribute='n')
+    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
+    assert_extractor_output(reader, 'I')
+
+    extractor = XML(FindParentTag('scene'), attribute='n')
+    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
+    assert_extractor_output(reader, 'V')
 
 
 def test_xml_multiple_attributes(tmpdir):

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -43,31 +43,31 @@ def assert_extractor_output(reader, expected):
 
 
 def test_xml_basic(tmpdir):
-    extractor = XML(tag='character')
+    extractor = XML(XMLTag('character'))
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
 
 def test_xml_re_pattern_tag(tmpdir):
-    extractor = XML(tag=re.compile(r'ch.r'))
+    extractor = XML(XMLTag(re.compile(r'ch.r')))
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
 
 def test_xml_transform(tmpdir):
-    extractor = XML(tag='character', transform=str.title)
+    extractor = XML(XMLTag('character'), transform=str.title)
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'Hamlet')
 
 
 def test_xml_no_tag(tmpdir):
-    extractor = XML()
+    extractor = XML(None)
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('character'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
 
 def test_xml_parent_level(tmpdir):
-    extractor = XML('character', parent_level=1)
+    extractor = XML(XMLTag('character'), parent_level=1)
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('l'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
@@ -83,11 +83,11 @@ doc_with_attribute = '''
 
 
 def test_xml_attribute(tmpdir):
-    extractor = XML(tag=None, attribute='character')
+    extractor = XML(None, attribute='character')
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_with_attribute, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
-    extractor = XML(tag='l', attribute='n')
+    extractor = XML(XMLTag('l'), attribute='n')
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_with_attribute, tmpdir)
     assert_extractor_output(reader, '1')
 
@@ -103,14 +103,14 @@ doc_multiline = '''
 '''
 
 def test_xml_flatten(tmpdir):
-    extractor = XML(tag=None, flatten=True)
+    extractor = XML(None, flatten=True)
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_multiline, tmpdir)
     expected = 'My hour is almost come, When I to sulph\'rous and tormenting flames Must render up myself.'
     assert_extractor_output(reader, expected)
 
 
 def test_xml_multiple(tmpdir):
-    extractor = XML(tag='l', multiple=True)
+    extractor = XML(XMLTag('l'), multiple=True)
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_multiline, tmpdir)
     expected = [
         'My hour is almost come,',
@@ -147,50 +147,50 @@ doc_nested = '''
 '''
 
 def test_xml_multiple_attributes(tmpdir):
-    extractor = XML(tag='lines', attribute='character', multiple=True)
+    extractor = XML(XMLTag('lines'), attribute='character', multiple=True)
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_nested, tmpdir)
     assert_extractor_output(reader, ['HAMLET', 'GHOST'])
 
 
 def test_xml_recursive(tmpdir):
-    extractor = XML(tag='l')
+    extractor = XML(XMLTag('l', recursive=False))
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_nested, tmpdir)
     assert_extractor_output(reader, None)
 
-    extractor = XML(tag='l', recursive=True)
+    extractor = XML(XMLTag('l'))
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'Whither wilt thou lead me? Speak, I\'ll go no further.')
 
 
 def test_xml_tag_list(tmpdir):
-    extractor = XML(tag=['lines', 'l'])
+    extractor = XML([XMLTag('lines'), XMLTag('l')])
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'Whither wilt thou lead me? Speak, I\'ll go no further.')
 
 
 def test_xml_transform_soup_func(tmpdir):
     find_location = lambda soup: soup.find_previous_sibling('location')
-    extractor = XML(tag=None, transform_soup_func=find_location)
+    extractor = XML(None, transform_soup_func=find_location)
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'A more remote part of the Castle.')
 
 
 def test_xml_extract_soup_func(tmpdir):
     get_scene_number = lambda soup: soup.find_parent('scene')['n']
-    extractor = XML(tag=None, extract_soup_func=get_scene_number)
+    extractor = XML(None, extract_soup_func=get_scene_number)
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'V')
 
 
 def test_xml_entry_tag_kwargs(tmpdir):
-    extractor = XML('l')
+    extractor = XML(XMLTag('l'))
     entry_tag = XMLTag(name='lines', character='GHOST')
     reader = make_test_reader(extractor, XMLTag('play'), entry_tag, doc_nested, tmpdir)
     assert_extractor_output(reader, 'Mark me.')
 
 
 def test_xml_toplevel_tag_kwargs(tmpdir):
-    extractor = XML('l')
+    extractor = XML(XMLTag('l'))
     toplevel_tag = XMLTag(name='act', n='III')
     reader = make_test_reader(extractor, toplevel_tag, XMLTag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'To be, or not to be, that is the question.')
@@ -217,7 +217,7 @@ doc_longer = '''
 
 
 def test_xml_secondary_tag(tmpdir):
-    extractor = XML('l', secondary_tag={'tag': 'character', 'exact': 'GHOST'})
+    extractor = XML(XMLTag('l'), secondary_tag={'tag': 'character', 'exact': 'GHOST'})
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_longer, tmpdir)
     assert_extractor_output(reader, 'Mark me.')
 
@@ -266,14 +266,14 @@ def test_xml_external_file(tmpdir):
             Field(
                 name='author',
                 extractor=XML(
-                    'author',
+                    XMLTag('author'),
                     secondary_tag={'tag': 'title', 'match': 'title'},
                     external_file={'xml_tag_toplevel': XMLTag('bibliography'), 'xml_tag_entry': None}
                 )
             ),
             Field(
                 name='title',
-                extractor=XML('title', toplevel=True)
+                extractor=XML(XMLTag('title'), toplevel=True)
             )
         ]
     

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -285,6 +285,7 @@ def test_xml_external_file(tmpdir):
         data_directory = tmpdir
         tag_toplevel = XMLTag('play')
         tag_entry = XMLTag('lines')
+        external_file_tag_toplevel = XMLTag('bibliography')
 
         def sources(self, *args, **kwargs):
             yield path, {'external_file': external_path}
@@ -297,7 +298,7 @@ def test_xml_external_file(tmpdir):
                         lambda metadata: XMLTag('title', string=metadata['title']),
                         SiblingTag('author')
                     ],
-                    external_file={'xml_tag_toplevel': XMLTag('bibliography'), 'xml_tag_entry': None}
+                    external_file=True
                 )
             ),
             Field(

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -4,8 +4,8 @@ import re
 from ianalyzer_readers.readers.xml import XMLReader
 from ianalyzer_readers.extract import XML
 from ianalyzer_readers.readers.core import Field
-from ianalyzer_readers.utils import (
-    XMLTag, ParentTag, FindParentTag, SiblingTag, CurrentTag, TransformTag
+from ianalyzer_readers.xml_tag import (
+    Tag, ParentTag, FindParentTag, SiblingTag, CurrentTag, TransformTag
 ) 
 
 
@@ -45,26 +45,26 @@ def assert_extractor_output(reader, expected):
 
 
 def test_xml_basic(tmpdir):
-    extractor = XML(XMLTag('character'))
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), basic_doc, tmpdir)
+    extractor = XML(Tag('character'))
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
 
 def test_xml_re_pattern_tag(tmpdir):
-    extractor = XML(XMLTag(re.compile(r'ch.r')))
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), basic_doc, tmpdir)
+    extractor = XML(Tag(re.compile(r'ch.r')))
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
 
 def test_xml_transform(tmpdir):
-    extractor = XML(XMLTag('character'), transform=str.title)
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), basic_doc, tmpdir)
+    extractor = XML(Tag('character'), transform=str.title)
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'Hamlet')
 
 
 def test_xml_no_tag(tmpdir):
     extractor = XML(CurrentTag())
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('character'), basic_doc, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('character'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
 
@@ -81,11 +81,11 @@ doc_with_attribute = '''
 
 def test_xml_attribute(tmpdir):
     extractor = XML(CurrentTag(), attribute='character')
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_with_attribute, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_with_attribute, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
-    extractor = XML(XMLTag('l'), attribute='n')
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_with_attribute, tmpdir)
+    extractor = XML(Tag('l'), attribute='n')
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_with_attribute, tmpdir)
     assert_extractor_output(reader, '1')
 
 doc_multiline = '''
@@ -101,14 +101,14 @@ doc_multiline = '''
 
 def test_xml_flatten(tmpdir):
     extractor = XML(CurrentTag(), flatten=True)
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_multiline, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_multiline, tmpdir)
     expected = 'My hour is almost come, When I to sulph\'rous and tormenting flames Must render up myself.'
     assert_extractor_output(reader, expected)
 
 
 def test_xml_multiple(tmpdir):
-    extractor = XML(XMLTag('l'), multiple=True)
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_multiline, tmpdir)
+    extractor = XML(Tag('l'), multiple=True)
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_multiline, tmpdir)
     expected = [
         'My hour is almost come,',
         'When I to sulph\'rous and tormenting flames',
@@ -146,71 +146,71 @@ doc_nested = '''
 
 def test_xml_parent_tag(tmpdir):
     extractor = XML(ParentTag(), attribute='n')
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'V')
 
     extractor = XML(ParentTag(2), attribute='n')
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'I')
 
 
 def test_xml_find_parent_tag(tmpdir):
     extractor = XML(FindParentTag('act'), attribute='n')
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'I')
 
     extractor = XML(FindParentTag('scene'), attribute='n')
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'V')
 
 
 def test_xml_multiple_attributes(tmpdir):
-    extractor = XML(XMLTag('lines'), attribute='character', multiple=True)
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_nested, tmpdir)
+    extractor = XML(Tag('lines'), attribute='character', multiple=True)
+    reader = make_test_reader(extractor, Tag('play'), Tag('scene'), doc_nested, tmpdir)
     assert_extractor_output(reader, ['HAMLET', 'GHOST'])
 
 
 def test_xml_recursive(tmpdir):
-    extractor = XML(XMLTag('l', recursive=False))
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_nested, tmpdir)
+    extractor = XML(Tag('l', recursive=False))
+    reader = make_test_reader(extractor, Tag('play'), Tag('scene'), doc_nested, tmpdir)
     assert_extractor_output(reader, None)
 
-    extractor = XML(XMLTag('l'))
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_nested, tmpdir)
+    extractor = XML(Tag('l'))
+    reader = make_test_reader(extractor, Tag('play'), Tag('scene'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'Whither wilt thou lead me? Speak, I\'ll go no further.')
 
 
 def test_xml_tag_list(tmpdir):
-    extractor = XML([XMLTag('lines'), XMLTag('l')])
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_nested, tmpdir)
+    extractor = XML([Tag('lines'), Tag('l')])
+    reader = make_test_reader(extractor, Tag('play'), Tag('scene'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'Whither wilt thou lead me? Speak, I\'ll go no further.')
 
 
 def test_xml_transform_tag(tmpdir):
     find_location = lambda soup: soup.find_previous_sibling('location')
     extractor = XML(TransformTag(find_location))
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'A more remote part of the Castle.')
 
 
 def test_xml_extract_soup_func(tmpdir):
     get_scene_number = lambda soup: soup.find_parent('scene')['n']
     extractor = XML(CurrentTag(), extract_soup_func=get_scene_number)
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'V')
 
 
 def test_xml_entry_tag_kwargs(tmpdir):
-    extractor = XML(XMLTag('l'))
-    entry_tag = XMLTag(name='lines', character='GHOST')
-    reader = make_test_reader(extractor, XMLTag('play'), entry_tag, doc_nested, tmpdir)
+    extractor = XML(Tag('l'))
+    entry_tag = Tag(name='lines', character='GHOST')
+    reader = make_test_reader(extractor, Tag('play'), entry_tag, doc_nested, tmpdir)
     assert_extractor_output(reader, 'Mark me.')
 
 
 def test_xml_toplevel_tag_kwargs(tmpdir):
-    extractor = XML(XMLTag('l'))
-    toplevel_tag = XMLTag(name='act', n='III')
-    reader = make_test_reader(extractor, toplevel_tag, XMLTag('lines'), doc_nested, tmpdir)
+    extractor = XML(Tag('l'))
+    toplevel_tag = Tag(name='act', n='III')
+    reader = make_test_reader(extractor, toplevel_tag, Tag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'To be, or not to be, that is the question.')
 
 doc_longer = '''
@@ -236,14 +236,14 @@ doc_longer = '''
 
 def test_xml_sibling_tag(tmpdir):
     extractor = XML(SiblingTag('character'))
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('l'), doc_longer, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('l'), doc_longer, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
     extractor = XML([
-        XMLTag('character', string='GHOST'),
+        Tag('character', string='GHOST'),
         SiblingTag('l')
     ])
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_longer, tmpdir)
+    reader = make_test_reader(extractor, Tag('play'), Tag('scene'), doc_longer, tmpdir)
     assert_extractor_output(reader, 'Mark me.')
 
 
@@ -283,9 +283,9 @@ def test_xml_external_file(tmpdir):
 
     class TestReader(XMLReader):
         data_directory = tmpdir
-        tag_toplevel = XMLTag('play')
-        tag_entry = XMLTag('lines')
-        external_file_tag_toplevel = XMLTag('bibliography')
+        tag_toplevel = Tag('play')
+        tag_entry = Tag('lines')
+        external_file_tag_toplevel = Tag('bibliography')
 
         def sources(self, *args, **kwargs):
             yield path, {'external_file': external_path}
@@ -295,7 +295,7 @@ def test_xml_external_file(tmpdir):
                 name='author',
                 extractor=XML(
                     [
-                        lambda metadata: XMLTag('title', string=metadata['title']),
+                        lambda metadata: Tag('title', string=metadata['title']),
                         SiblingTag('author')
                     ],
                     external_file=True
@@ -303,7 +303,7 @@ def test_xml_external_file(tmpdir):
             ),
             Field(
                 name='title',
-                extractor=XML(XMLTag('title'), toplevel=True)
+                extractor=XML(Tag('title'), toplevel=True)
             )
         ]
     

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -295,7 +295,6 @@ def test_xml_external_file(tmpdir):
                         lambda metadata: XMLTag('title', string=metadata['title']),
                         SiblingTag('author')
                     ],
-                    sibling_tag = lambda metadata: XMLTag('title', string=metadata['title']),
                     external_file={'xml_tag_toplevel': XMLTag('bibliography'), 'xml_tag_entry': None}
                 )
             ),

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -216,8 +216,11 @@ doc_longer = '''
 '''
 
 
-def test_xml_secondary_tag(tmpdir):
-    extractor = XML(XMLTag('l'), secondary_tag={'tag': 'character', 'exact': 'GHOST'})
+def test_xml_sibling_tag(tmpdir):
+    extractor = XML(
+        XMLTag('l'),
+        sibling_tag=XMLTag('character', string='GHOST')
+    )
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('scene'), doc_longer, tmpdir)
     assert_extractor_output(reader, 'Mark me.')
 
@@ -267,7 +270,7 @@ def test_xml_external_file(tmpdir):
                 name='author',
                 extractor=XML(
                     XMLTag('author'),
-                    secondary_tag={'tag': 'title', 'match': 'title'},
+                    sibling_tag = lambda metadata: XMLTag('title', string=metadata['title']),
                     external_file={'xml_tag_toplevel': XMLTag('bibliography'), 'xml_tag_entry': None}
                 )
             ),

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -5,7 +5,7 @@ from ianalyzer_readers.readers.xml import XMLReader
 from ianalyzer_readers.extract import XML
 from ianalyzer_readers.readers.core import Field
 from ianalyzer_readers.utils import (
-    XMLTag, ParentTag, FindParentTag, SiblingTag, TransformTag
+    XMLTag, ParentTag, FindParentTag, SiblingTag, CurrentTag, TransformTag
 ) 
 
 
@@ -63,7 +63,7 @@ def test_xml_transform(tmpdir):
 
 
 def test_xml_no_tag(tmpdir):
-    extractor = XML(None)
+    extractor = XML(CurrentTag())
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('character'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
@@ -80,7 +80,7 @@ doc_with_attribute = '''
 
 
 def test_xml_attribute(tmpdir):
-    extractor = XML(None, attribute='character')
+    extractor = XML(CurrentTag(), attribute='character')
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_with_attribute, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
@@ -100,7 +100,7 @@ doc_multiline = '''
 '''
 
 def test_xml_flatten(tmpdir):
-    extractor = XML(None, flatten=True)
+    extractor = XML(CurrentTag(), flatten=True)
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_multiline, tmpdir)
     expected = 'My hour is almost come, When I to sulph\'rous and tormenting flames Must render up myself.'
     assert_extractor_output(reader, expected)
@@ -195,7 +195,7 @@ def test_xml_transform_tag(tmpdir):
 
 def test_xml_extract_soup_func(tmpdir):
     get_scene_number = lambda soup: soup.find_parent('scene')['n']
-    extractor = XML(None, extract_soup_func=get_scene_number)
+    extractor = XML(CurrentTag(), extract_soup_func=get_scene_number)
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'V')
 

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -268,7 +268,7 @@ def test_xml_external_file(tmpdir):
                 extractor=XML(
                     'author',
                     secondary_tag={'tag': 'title', 'match': 'title'},
-                    external_file={'xml_tag_toplevel': 'bibliography', 'xml_tag_entry': None}
+                    external_file={'xml_tag_toplevel': XMLTag('bibliography'), 'xml_tag_entry': None}
                 )
             ),
             Field(

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -4,7 +4,7 @@ import re
 from ianalyzer_readers.readers.xml import XMLReader
 from ianalyzer_readers.extract import XML
 from ianalyzer_readers.readers.core import Field
-from ianalyzer_readers.utils import XMLTag
+from ianalyzer_readers.utils import XMLTag, ParentTag
 
 
 def make_test_reader(extractor, toplevel_tag, entry_tag, doc, tmpdir):
@@ -65,11 +65,6 @@ def test_xml_no_tag(tmpdir):
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('character'), basic_doc, tmpdir)
     assert_extractor_output(reader, 'HAMLET')
 
-
-def test_xml_parent_level(tmpdir):
-    extractor = XML(XMLTag('character'), parent_level=1)
-    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('l'), basic_doc, tmpdir)
-    assert_extractor_output(reader, 'HAMLET')
 
 
 doc_with_attribute = '''
@@ -145,6 +140,17 @@ doc_nested = '''
     </act>
 </play>
 '''
+
+
+def test_xml_parent_tag(tmpdir):
+    extractor = XML(ParentTag(), attribute='n')
+    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
+    assert_extractor_output(reader, 'V')
+
+    extractor = XML(ParentTag(2), attribute='n')
+    reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
+    assert_extractor_output(reader, 'I')
+
 
 def test_xml_multiple_attributes(tmpdir):
     extractor = XML(XMLTag('lines'), attribute='character', multiple=True)

--- a/tests/xml/test_xml_extraction.py
+++ b/tests/xml/test_xml_extraction.py
@@ -4,7 +4,9 @@ import re
 from ianalyzer_readers.readers.xml import XMLReader
 from ianalyzer_readers.extract import XML
 from ianalyzer_readers.readers.core import Field
-from ianalyzer_readers.utils import XMLTag, ParentTag, FindParentTag, SiblingTag
+from ianalyzer_readers.utils import (
+    XMLTag, ParentTag, FindParentTag, SiblingTag, TransformTag
+) 
 
 
 def make_test_reader(extractor, toplevel_tag, entry_tag, doc, tmpdir):
@@ -184,9 +186,9 @@ def test_xml_tag_list(tmpdir):
     assert_extractor_output(reader, 'Whither wilt thou lead me? Speak, I\'ll go no further.')
 
 
-def test_xml_transform_soup_func(tmpdir):
+def test_xml_transform_tag(tmpdir):
     find_location = lambda soup: soup.find_previous_sibling('location')
-    extractor = XML(None, transform_soup_func=find_location)
+    extractor = XML(TransformTag(find_location))
     reader = make_test_reader(extractor, XMLTag('play'), XMLTag('lines'), doc_nested, tmpdir)
     assert_extractor_output(reader, 'A more remote part of the Castle.')
 

--- a/tests/xml/test_xml_reader.py
+++ b/tests/xml/test_xml_reader.py
@@ -3,7 +3,7 @@ import os
 from ianalyzer_readers.readers.xml import XMLReader
 from ianalyzer_readers.readers.core import Field
 from ianalyzer_readers.extract import XML
-from ianalyzer_readers.utils import XMLTag
+from ianalyzer_readers.utils import XMLTag, CurrentTag
 
 class HamletXMLReader(XMLReader):
     """
@@ -31,7 +31,7 @@ class HamletXMLReader(XMLReader):
     )
     character = Field(
         'character',
-        XML(None, attribute='character')
+        XML(CurrentTag(), attribute='character')
     )
     lines = Field(
         'lines',

--- a/tests/xml/test_xml_reader.py
+++ b/tests/xml/test_xml_reader.py
@@ -3,6 +3,7 @@ import os
 from ianalyzer_readers.readers.xml import XMLReader
 from ianalyzer_readers.readers.core import Field
 from ianalyzer_readers.extract import XML
+from ianalyzer_readers.utils import XMLTag
 
 class HamletXMLReader(XMLReader):
     """
@@ -11,8 +12,8 @@ class HamletXMLReader(XMLReader):
 
     data_directory = os.path.join(os.path.dirname(__file__), 'data')
 
-    tag_toplevel = 'document'
-    tag_entry = 'lines'
+    tag_toplevel = XMLTag('document')
+    tag_entry = XMLTag('lines')
 
     def sources(self, **kwargs):
         for filename in os.listdir(self.data_directory):

--- a/tests/xml/test_xml_reader.py
+++ b/tests/xml/test_xml_reader.py
@@ -3,7 +3,7 @@ import os
 from ianalyzer_readers.readers.xml import XMLReader
 from ianalyzer_readers.readers.core import Field
 from ianalyzer_readers.extract import XML
-from ianalyzer_readers.utils import XMLTag, CurrentTag
+from ianalyzer_readers.xml_tag import Tag, CurrentTag
 
 class HamletXMLReader(XMLReader):
     """
@@ -12,8 +12,8 @@ class HamletXMLReader(XMLReader):
 
     data_directory = os.path.join(os.path.dirname(__file__), 'data')
 
-    tag_toplevel = XMLTag('document')
-    tag_entry = XMLTag('lines')
+    tag_toplevel = Tag('document')
+    tag_entry = Tag('lines')
 
     def sources(self, **kwargs):
         for filename in os.listdir(self.data_directory):
@@ -25,7 +25,7 @@ class HamletXMLReader(XMLReader):
     title = Field(
         'title',
         XML(
-            XMLTag('title'),
+            Tag('title'),
             toplevel=True
         )
     )
@@ -36,7 +36,7 @@ class HamletXMLReader(XMLReader):
     lines = Field(
         'lines',
         XML(
-            XMLTag('l'),
+            Tag('l'),
             multiple=True,
             transform='\n'.join
         ),

--- a/tests/xml/test_xml_reader.py
+++ b/tests/xml/test_xml_reader.py
@@ -24,7 +24,10 @@ class HamletXMLReader(XMLReader):
 
     title = Field(
         'title',
-        XML('title', toplevel=True, recursive=True)
+        XML(
+            XMLTag('title'),
+            toplevel=True
+        )
     )
     character = Field(
         'character',
@@ -32,7 +35,11 @@ class HamletXMLReader(XMLReader):
     )
     lines = Field(
         'lines',
-        XML('l', multiple=True, transform='\n'.join),
+        XML(
+            XMLTag('l'),
+            multiple=True,
+            transform='\n'.join
+        ),
     )
 
     fields = [title, character, lines]


### PR DESCRIPTION
This is a major refactor of the XML reader. It contains breaking changes to the API for `XMLReader`, `HTMLReader`, and the `XML` extractor. Everything that was previously possible when extracting XML documents is still possible, but the code must be adjusted.

The main goal is to make the interface of the reader less confusing. I focused on a few "pain points":
- There were quite a few places where you would define a tag to look for, but each had its own system.
- The `XML` extractor had a lot of options that were difficult to oversee. The interactions between these properties was often unpredictable and/or buggy. This update reduces the  number of arguments by making "tag chaining" much more powerful. 
- Searching for tags leans more heavily on the filter syntax from BeautifulSoup, since that's a fine system already.

The core concept of searching the XML tree is to provide a chain of `Tag` objects. A minimal example is

```python
XML(Tag('a')) # a child tag `<a>`
```

But you can get really wild here:

```python
XML(
	ParentTag(2), # move up two steps in the tree
	SiblingTag(role='meta'), # a sibling with `role=meta` attribute
	lambda metadata: Tag('id', string=metadata['id']), # an <id> tag whose contents match the metadata field 'id'
	TransformTag(find_metadata), # handle complex manoeuvre in custom function
	Tag('author'), # child tag <author>
	Tag(re.compile(r'(first|last)Name')), # child tag <firstName> or <lastName>
)
```

Creating a general system for searching for tags also means that the interface is much more powerful. Everything that was supported _somewhere_ is now supported _everywhere_. For example, this code above illustrates a few things you could not do before:

- identify a sibling tag (secondary tag) by any means other than string content
- match a tag to metadata when it's not a sibling of the target tag
- use a custom transform function but don't make it the last step in the chain

Documentation and test coverage should be as complete as it was before (probably more so), but I intend to add some more documentation in a future PR before we use this in I-analyzer.

close #17 , close #10 , close #9

### Breaking changes

#### `XMLReader`
- `tag_entry` must now be a `Tag` or a callable that returns a `Tag` based on the document metadata.
- Idem for `tag_toplevel`
- If you want to use the `external_file` option of the `XML` extractor, the toplevel tag of external files should now be configured in the `external_file_tag_top_level` attribute rather than the extractor of each field.

Changes to default behaviour:
- If an `XML` extractor has `external_file=True` and the reader did not receive document metadata (which should supply the file), the value of the field will be `None`. The extractor will not be applied to the primary document.

#### `XML` extractor
- `tag` parameter is now `tags`, which takes a variable number of arguments. (Instead of optionally taking a list.) Each argument must be a `Tag` or a callable that returns a `Tag` based on the document metadata.
- `parent_level` parameter is removed. You can migrate this query using a `ParentTag` in the `tags`.
- `secondary_tag` parameter is removed. You can migrate this query by using a `SiblingTag` in the `tags`. If you need to match a tag's content with document metadata, use a callable in the `tags`.
- `recursive` parameter is removed. Searching recursively can be configured in each of the `tags` where applicable.
- `transform_soup_func` is removed. You can migrate this query by using a `TransformTag`.
- `external_file` parameter is now a boolean. (The toplevel tag of the external file is now configured in the `XMLReader`.)

Changes to the default behaviour:
- While `SiblingTag` is the most natural successor to `secondary_tag`, an element is not its own sibling, while `secondary_tag` did allow elements to be their own secondary tag. For the old behaviour, use a `ParentTag` to traverse the tree instead of a `SiblingTag`.
- Child tags are now searched recursively by default, as this is the behaviour of `soup.find_all()` in BeautifulSoup. Use `Tag(recursive=False)` for the old behaviour.
- A chain of tags, e.g. `XML(Tag('a'), Tag('b'))` will identify more matches than the old `XML(['a', 'b'])`. In this example, the extractor now searches for "any `b` tag that is a child of any `a` tag", rather than "any `b` tag that is a child of the _first_ `a` tag". For instance, in `<a></a><a><b></b></a>`, the old version would not have found a match, but the new version will.  If you want the old behaviour, use `XML(Tag('a', limit=1), Tag('b'))