### PR TITLE
feat: allow reading multiple files for RDFReader

### DIFF
--- a/ianalyzer_readers/readers/rdf.py
+++ b/ianalyzer_readers/readers/rdf.py
@@ -4,13 +4,15 @@ This module defines a Resource Description Framework (RDF) reader.
 Extraction is based on the [rdflib library](https://rdflib.readthedocs.io/en/stable/index.html).
 '''
 
-from typing import Iterable, Union
+from glob import glob
+from typing import Dict, Iterable, Tuple, Union
 
 from rdflib import BNode, Graph, Literal, URIRef
 
 from .core import Reader, Document, Source
 import ianalyzer_readers.extract as extract
 
+Subject = Union[BNode, Literal, URIRef]
 
 class RDFReader(Reader):
     '''
@@ -19,12 +21,38 @@ class RDFReader(Reader):
     see [rdflib parsers](https://rdflib.readthedocs.io/en/stable/plugin_parsers.html).
     '''
 
-    def source2dicts(self, source: Source) -> Iterable[Document]:
+    def sources(self, **kwargs):
+        ''' The RDFReader class overrides, atypically, the `sources` property
+        to coerce the output of this function to RDF subjects, rather than file names.
+        In order to adjust the strategy by which RDF files are located,
+        override the `file_selector` function.
         '''
-        Given a RDF source file, returns an iterable of extracted documents.
+        files = self.file_selector()
+        graph = Graph()
+        for input_file in files:
+            graph.parse(input_file)
+        self.graph = graph
+        for subject in self.document_subjects(graph):
+            yield subject
+    
+    def file_selector(self) -> Iterable:
+        ''' A function to locate potential RDF files
+        This function assumes all files are contained within one directory
+        Override this function for more complex directory structure
+        and/or if rules for file selection should be applied.
+        '''
+        allowed_file_extensions = ['ttl', 'xml', 'json', 'rdf']
+        files = []
+        for extension in allowed_file_extensions:
+            files.extend(glob(f'{self.data_directory}/*.{extension}'))
+        return files
+
+    def source2dicts(self, source: Union[Subject, Tuple[Subject, Dict]]) -> Iterable[Document]:
+        '''
+        Given a URIRef representing a subject, returns an iterable of extracted documents.
 
         Parameters:
-            source: the source file to extract. This can be a string of the file path, or a tuple of the file path and metadata.
+            source: the subject to extract. This is an URIRef, or a tuple of a URIRef and metadata.
 
         Returns:
             an iterable of document dictionaries. Each of these is a dictionary,
@@ -32,26 +60,16 @@ class RDFReader(Reader):
                 are based on the extractor of each field.
         '''
         self._reject_extractors(extract.CSV, extract.XML)
-        
-        metadata = None
-        if type(source) == tuple:
-            filename = source[0]
-            metadata = source[1]
-        elif type(source) == bytes:
-            raise Exception('The current reader cannot handle sources of bytes type, provide a file path as string instead')
+        if isinstance(source, URIRef):
+            subject = source
+            metadata = {}
+        elif isinstance(source, bytes):
+            raise NotImplementedError()
         else:
-            filename = source
-        g = Graph()
-        g.parse(filename)
-        document_subjects = self.document_subjects(g)
-        for subject in document_subjects:
-            content = self._document_from_subject(g, subject)
-            if metadata:
-                yield content, metadata
-            else:
-                yield content
+            subject, metadata = source
+        yield self._document_from_subject(subject, metadata)
 
-    def document_subjects(self, graph: Graph) -> Iterable[Union[BNode, Literal, URIRef]]:
+    def document_subjects(self, graph: Graph) -> Iterable[Subject]:
         ''' Override this function to return all subjects (i.e., first part of RDF triple) 
         with which to search for data in the RDF graph.
         Typically, such subjects are identifiers or urls.
@@ -64,5 +82,7 @@ class RDFReader(Reader):
         '''
         return graph.subjects()
 
-    def _document_from_subject(self, graph: Graph, subject: Union[BNode, Literal, URIRef]) -> dict:
-        return {field.name: field.extractor.apply(graph=graph, subject=subject) for field in self.fields}
+    def _document_from_subject(self, subject: Subject, metadata: Dict) -> Document:
+        return {field.name: field.extractor.apply(
+                graph=self.graph, subject=subject, metadata=metadata
+            ) for field in self.fields}

--- a/tests/rdf_reader.py
+++ b/tests/rdf_reader.py
@@ -28,12 +28,7 @@ class TestRDFReader(RDFReader):
     def document_subjects(self, graph: Graph):
         ''' get all subjects with a `hasSpeaker` predicate '''
         subjects = sorted(list(graph.subjects(URIRef(ns_speaker))))
-        return subjects
-
-    def sources(self, **kwargs):
-        for filename in glob(f'{self.data_directory}/*.ttl'):
-            full_path = os.path.join(self.data_directory, filename)
-            yield full_path
+        return subjects     
 
     identifier = Field(
         'id',
@@ -69,11 +64,11 @@ class TestRDFReader(RDFReader):
 def create_test_data():
     ''' Use the example.csv file to write a document in turtle format '''
     graph = Graph()
-    with open('./tests/csv_example/example.csv', 'r') as f:
+    with open('./tests/csv/data/Hamlet.csv', 'r') as f:
         reader = csv.DictReader(f)
         character = ''
         for index, row in enumerate(reader):
-            identifier = f'{ns_line_id}/hamlet-actI-scene5-{index}'
+            identifier = f'{ns_line_id}/hamlet-actI-scene5-{str(index).zfill(2)}'
             if character != row['character']:
                 character = row['character']
                 graph.add((URIRef(identifier),
@@ -85,15 +80,17 @@ def create_test_data():
             graph.add((URIRef(identifier),
                        RDF.first, Literal(row['line'])))
 
-            next_id = f'{ns_line_id}/hamlet-actI-scene5-{index+1}'
+            next_id = f'{ns_line_id}/hamlet-actI-scene5-{str(index+1).zfill(2)}'
             rest_triple = (URIRef(identifier),
                            RDF.rest, URIRef(next_id))
             graph.add(rest_triple)
 
         graph.remove(rest_triple)
+        graph.serialize(destination='./tests/ttl_example/hamlet.ttl')
+
+        graph = Graph()
         graph.add((URIRef(f'{ns_character}/HAMLET'),
                    URIRef(ns_opacity), Literal(1.0)))
         graph.add((URIRef(f'{ns_character}/GHOST'),
                    URIRef(ns_opacity), Literal(0.3)))
-
-        graph.serialize(destination='./tests/ttl_example/hamlet.ttl')
+        graph.serialize(destination='./tests/ttl_example/opacity.ttl')

--- a/tests/ttl_example/hamlet.ttl
+++ b/tests/ttl_example/hamlet.ttl
@@ -1,39 +1,35 @@
 @prefix ns1: <http://example.org/shakespeare/> .
-@prefix ns2: <http://example.org/vision/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://example.org/shakespeare/character/GHOST> ns2:hasOpacity 3e-01 .
+<http://example.org/shakespeare/line/hamlet-actI-scene5-00> rdf:first "SCENE V. A more remote part of the Castle." .
 
-<http://example.org/shakespeare/character/HAMLET> ns2:hasOpacity 1e+00 .
-
-<http://example.org/shakespeare/line/hamlet-actI-scene5-0> ns1:hasSpeaker <http://example.org/shakespeare/character/HAMLET> ;
+<http://example.org/shakespeare/line/hamlet-actI-scene5-01> ns1:hasSpeaker <http://example.org/shakespeare/character/HAMLET> ;
     rdf:first "Whither wilt thou lead me? Speak, I'll go no further." .
 
-<http://example.org/shakespeare/line/hamlet-actI-scene5-1> ns1:hasSpeaker <http://example.org/shakespeare/character/GHOST> ;
+<http://example.org/shakespeare/line/hamlet-actI-scene5-02> ns1:hasSpeaker <http://example.org/shakespeare/character/GHOST> ;
     rdf:first "Mark me." .
 
-<http://example.org/shakespeare/line/hamlet-actI-scene5-2> ns1:hasSpeaker <http://example.org/shakespeare/character/HAMLET> ;
+<http://example.org/shakespeare/line/hamlet-actI-scene5-03> ns1:hasSpeaker <http://example.org/shakespeare/character/HAMLET> ;
     rdf:first "I will." .
 
-<http://example.org/shakespeare/line/hamlet-actI-scene5-3> ns1:hasSpeaker <http://example.org/shakespeare/character/GHOST> ;
+<http://example.org/shakespeare/line/hamlet-actI-scene5-04> ns1:hasSpeaker <http://example.org/shakespeare/character/GHOST> ;
     rdf:first "My hour is almost come," ;
-    rdf:rest <http://example.org/shakespeare/line/hamlet-actI-scene5-4> .
+    rdf:rest <http://example.org/shakespeare/line/hamlet-actI-scene5-05> .
 
-<http://example.org/shakespeare/line/hamlet-actI-scene5-6> ns1:hasSpeaker <http://example.org/shakespeare/character/HAMLET> ;
+<http://example.org/shakespeare/line/hamlet-actI-scene5-07> ns1:hasSpeaker <http://example.org/shakespeare/character/HAMLET> ;
     rdf:first "Alas, poor ghost!" .
 
-<http://example.org/shakespeare/line/hamlet-actI-scene5-7> ns1:hasSpeaker <http://example.org/shakespeare/character/GHOST> ;
+<http://example.org/shakespeare/line/hamlet-actI-scene5-08> ns1:hasSpeaker <http://example.org/shakespeare/character/GHOST> ;
     rdf:first "Pity me not, but lend thy serious hearing" ;
-    rdf:rest <http://example.org/shakespeare/line/hamlet-actI-scene5-8> .
+    rdf:rest <http://example.org/shakespeare/line/hamlet-actI-scene5-09> .
 
-<http://example.org/shakespeare/line/hamlet-actI-scene5-9> ns1:hasSpeaker <http://example.org/shakespeare/character/HAMLET> ;
+<http://example.org/shakespeare/line/hamlet-actI-scene5-10> ns1:hasSpeaker <http://example.org/shakespeare/character/HAMLET> ;
     rdf:first "Speak, I am bound to hear." .
 
-<http://example.org/shakespeare/line/hamlet-actI-scene5-4> rdf:first "When I to sulph'rous and tormenting flames" ;
-    rdf:rest <http://example.org/shakespeare/line/hamlet-actI-scene5-5> .
+<http://example.org/shakespeare/line/hamlet-actI-scene5-05> rdf:first "When I to sulph'rous and tormenting flames" ;
+    rdf:rest <http://example.org/shakespeare/line/hamlet-actI-scene5-06> .
 
-<http://example.org/shakespeare/line/hamlet-actI-scene5-5> rdf:first "Must render up myself." .
+<http://example.org/shakespeare/line/hamlet-actI-scene5-06> rdf:first "Must render up myself." .
 
-<http://example.org/shakespeare/line/hamlet-actI-scene5-8> rdf:first "To what I shall unfold." .
+<http://example.org/shakespeare/line/hamlet-actI-scene5-09> rdf:first "To what I shall unfold." .
 

--- a/tests/ttl_example/opacity.ttl
+++ b/tests/ttl_example/opacity.ttl
@@ -1,0 +1,7 @@
+@prefix ns1: <http://example.org/vision/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/shakespeare/character/GHOST> ns1:hasOpacity 3e-01 .
+
+<http://example.org/shakespeare/character/HAMLET> ns1:hasOpacity 1e+00 .
+


### PR DESCRIPTION
Close #20 : this branch adds the functionality by which the `RDFReader` can read multiple files, combine them into one graph, and then read out the relevant data per subject.

This requires some wrangling of the `Reader` class, i.e., instead of a `str` (filepath), the `source2dict` method now expects a source argument of type `Subject`. The `sources` property is implemented on the `RDFReader` class now to pass out subjects. This means that in contrast to other corpora, a corpus using the `RDFReader` class will *not* have to implement `sources`, and typically override the `file_selector` method instead.