### PR TITLE
Feature/csv export

### DIFF
--- a/ianalyzer_readers/readers/core.py
+++ b/ianalyzer_readers/readers/core.py
@@ -8,8 +8,9 @@ The module defines two classes, `Field` and `Reader`.
 '''
 
 from .. import extract
-from typing import List, Iterable, Dict, Any, Union, Tuple
+from typing import List, Iterable, Dict, Any, Union, Tuple, Optional
 import logging
+import csv
 
 logging.basicConfig(level=logging.WARNING)
 logging.getLogger('ianalyzer-readers').setLevel(logging.DEBUG)
@@ -169,6 +170,20 @@ class Reader(object):
                     source
                 )
                 )
+
+    def export_csv(
+            self,
+            path: str,               
+            sources: Optional[Iterable[Source]] = None
+        ) -> None:
+            documents = self.documents(sources)
+
+            with open(path, 'w') as outfile:
+                writer = csv.DictWriter(outfile, self.fieldnames)
+                writer.writeheader()
+                for doc in documents:
+                    writer.writerow(doc)
+
 
     def _reject_extractors(self, *inapplicable_extractors: extract.Extractor):
         '''

--- a/ianalyzer_readers/readers/core.py
+++ b/ianalyzer_readers/readers/core.py
@@ -173,7 +173,7 @@ class Reader(object):
 
     def export_csv(self, path: str, sources: Optional[Iterable[Source]] = None) -> None:
         '''
-        Extracts documents from sources and saved them in a CSV file.
+        Extracts documents from sources and saves them in a CSV file.
 
         This will write a CSV file in the provided `path`. This method has no return
         value.

--- a/ianalyzer_readers/readers/core.py
+++ b/ianalyzer_readers/readers/core.py
@@ -171,18 +171,25 @@ class Reader(object):
                 )
                 )
 
-    def export_csv(
-            self,
-            path: str,               
-            sources: Optional[Iterable[Source]] = None
-        ) -> None:
-            documents = self.documents(sources)
+    def export_csv(self, path: str, sources: Optional[Iterable[Source]] = None) -> None:
+        '''
+        Extracts documents from sources and saved them in a CSV file.
 
-            with open(path, 'w') as outfile:
-                writer = csv.DictWriter(outfile, self.fieldnames)
-                writer.writeheader()
-                for doc in documents:
-                    writer.writerow(doc)
+        This will write a CSV file in the provided `path`. This method has no return
+        value.
+
+        Parameters:
+            path: the path where the CSV file should be saved.
+            sources: an iterable of paths to source files. If omitted, the reader class
+                will use the value of `self.sources()` instead.
+        '''
+        documents = self.documents(sources)
+
+        with open(path, 'w') as outfile:
+            writer = csv.DictWriter(outfile, self.fieldnames)
+            writer.writeheader()
+            for doc in documents:
+                writer.writerow(doc)
 
 
     def _reject_extractors(self, *inapplicable_extractors: extract.Extractor):

--- a/tests/test_csv_export.py
+++ b/tests/test_csv_export.py
@@ -1,0 +1,13 @@
+from . import html_reader
+import csv
+
+def test_csv_export(tmpdir):
+    reader = html_reader.HamletHTMLReader()
+    path = tmpdir / 'hamlet.csv'
+    reader.export_csv(path)
+
+    with open(path) as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+        assert csv_reader.fieldnames == reader.fieldnames
+        rows = list(row for row in csv_reader)
+        assert len(rows) == 7


### PR DESCRIPTION
Adds a method to export reader data to a CSV file. Close #4 

There is no configuration for the file format; since the implementation is quite simple, I would say: if you need detailed control over the file, it's easier to just write your own function.

However, since this is mostly an i-analyzer support package, this method should save a CSV that's ready for usage in I-analyzer's upcoming add-your-own-corpus interface. @JeltevanBoheemen , is there something about the data format that should be adjusted so it's compatible?