### PR TITLE
Allow source as bytes when first part of tuple

### DIFF
--- a/ianalyzer_readers/readers/core.py
+++ b/ianalyzer_readers/readers/core.py
@@ -14,7 +14,7 @@ import logging
 logging.basicConfig(level=logging.WARNING)
 logging.getLogger('ianalyzer-readers').setLevel(logging.DEBUG)
 
-Source = Union[str, Tuple[str, Dict], bytes]
+Source = Union[str, Tuple[Union[str, bytes], Dict], bytes]
 '''
 Type definition for the source input to some Reader methods.
 

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -178,8 +178,12 @@ class XMLReader(Reader):
             filename = None
             metadata = {}
         else:
-            filename = source[0]
-            soup = self._soup_from_xml(filename)
+            if isinstance(source[0], str):
+                filename = source[0]
+                soup = self._soup_from_xml(filename)
+            else:
+                filename = None
+                soup = self._soup_from_data(source[0])
             metadata = source[1] or None
         return filename, soup, metadata
 

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -6,6 +6,7 @@ Extraction is based on BeautifulSoup.
 
 import bs4
 import logging
+from os.path import isfile
 from typing import Dict, Iterable, Tuple, List
 
 from .. import extract
@@ -178,7 +179,7 @@ class XMLReader(Reader):
             filename = None
             metadata = {}
         else:
-            if isinstance(source[0], str):
+            if isfile(source[0]):
                 filename = source[0]
                 soup = self._soup_from_xml(filename)
             else:


### PR DESCRIPTION
This branch makes it possible to pass in bytes as the first part of a tuple. Needed for [Gallica corpus definition](https://github.com/CentreForDigitalHumanities/I-analyzer/pull/1692).