### PR TITLE
fix for identifying external fields when FieldDefinition is not static

### DIFF
--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -99,7 +99,7 @@ class XMLReader(Reader):
         external_fields = self._external_fields()
         # fields should have unique names, but may not have unique instantiations
         # if FieldDefinitions are created on the fly, for example with class methods or @propertys
-        external_fields_names = [field.name for field in external_fields]
+        external_fields_names = set(field.name for field in external_fields)
         regular_fields = [
             field for field in self.fields
             if field.name not in external_fields_names

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -97,8 +97,12 @@ class XMLReader(Reader):
 
     def extract_document(self, **document_data) -> Document:
         external_fields = self._external_fields()
-        regular_fields = [field for field in self.fields if
-            field not in external_fields
+        # fields should have unique names, but may not have unique instantiations
+        # if FieldDefinitions are created on the fly, for example with class methods or @propertys
+        external_fields_names = [field.name for field in external_fields]
+        regular_fields = [
+            field for field in self.fields
+            if field.name not in external_fields_names
         ]
 
         field_dict = {

--- a/ianalyzer_readers/readers/xml.py
+++ b/ianalyzer_readers/readers/xml.py
@@ -97,7 +97,7 @@ class XMLReader(Reader):
 
     def extract_document(self, **document_data) -> Document:
         external_fields = self._external_fields()
-        # fields should have unique names, but may not have unique instantiations
+        # fields should have unique names, but may not have stable instantiations
         # if FieldDefinitions are created on the fly, for example with class methods or @propertys
         external_fields_names = set(field.name for field in external_fields)
         regular_fields = [


### PR DESCRIPTION
When creating base corpus definitions that are meant to be derived, it is useful to define fields in class methods or `@property`s, so that they may be overridden in child classes.
This caused a bug in combination with the `external_file` setting, because the field would be considered both as an external field and a regular one. That's because the field definition is not static and cannot be used for testing set membership.