### PR TITLE
replace soup.find_all with a generator

### DIFF
--- a/ianalyzer_readers/xml_tag.py
+++ b/ianalyzer_readers/xml_tag.py
@@ -69,7 +69,10 @@ class Tag:
         returns a generator or a `bs4.ResultSet` rather than collecting all results up
         front.
         '''
-        return soup.find_all(*self.args, **self.kwargs)
+        result = soup.find(*self.args, **self.kwargs)
+        while result is not None:
+            yield result
+            result = result.find_next(*self.args, **self.kwargs)
 
 
 class CurrentTag(Tag):

--- a/ianalyzer_readers/xml_tag.py
+++ b/ianalyzer_readers/xml_tag.py
@@ -69,10 +69,16 @@ class Tag:
         returns a generator or a `bs4.ResultSet` rather than collecting all results up
         front.
         '''
-        result = soup.find(*self.args, **self.kwargs)
-        while result is not None:
-            yield result
-            result = result.find_next(*self.args, **self.kwargs)
+        pool = soup.descendants if self.kwargs.get('recursive', True) else soup.children
+
+        def strainer_helper(name=None, attrs={}, string=None, **kwargs):
+            return bs4.SoupStrainer(name, attrs, string, **kwargs)
+        strainer = strainer_helper(*self.args, **self.kwargs)
+
+        for element in pool:
+            result = strainer.search(element)
+            if result:
+                yield result
 
 
 class CurrentTag(Tag):


### PR DESCRIPTION
Looking at the design of `XML._select()` I have the impression that it's built on the assumption that BS4's lookup is lazy.

However, `find_all()` seems to be aggregating all results upfront: https://github.com/tec-cloud/beautifulsoup/blob/4.12.2/bs4/element.py#L835
Therefore I propose to use `find_next()` wrapped in our own generator. 