### PR TITLE
Feature/etree xml parser

### DIFF
--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -16,7 +16,6 @@ import bs4
 import html
 from rdflib import BNode, Graph, Literal, URIRef
 from rdflib.collection import Collection
-from xml.etree.ElementTree import Element
 
 logger = logging.getLogger()
 
@@ -500,7 +499,7 @@ class XPath(Extractor):
         self.toplevel = toplevel
         self.attribute = attribute
 
-    def _select(self, element: Element, root: Element) -> List[Element]:
+    def _select(self, element, root) -> List:
         el = root if self.toplevel else element
         if self.multiple:
             return el.findall(self.xpath)
@@ -508,13 +507,13 @@ class XPath(Extractor):
             return [el.find(self.xpath)]
 
 
-    def _extract(self, element: Element):
+    def _extract(self, element):
         if self.attribute:
             return element.get(self.attribute, None)
         return element.text
 
 
-    def _apply(self, element: Element, root: Element, *nargs, **kwargs):
+    def _apply(self, element, root, *nargs, **kwargs):
         elements = self._select(element, root)
         if self.multiple:
             return list(map(self._extract, elements))

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -16,6 +16,7 @@ import bs4
 import html
 from rdflib import BNode, Graph, Literal, URIRef
 from rdflib.collection import Collection
+from xml.etree.ElementTree import Element
 
 logger = logging.getLogger()
 
@@ -479,6 +480,47 @@ class XML(Extractor):
                 node.attrs.get(self.attribute)
                 for node in soup if node.attrs.get(self.attribute) is not None
             ]
+
+
+class XPath(Extractor):
+    '''
+    Extractor for XML data from the EtreeXMLReader
+    '''
+
+    def __init__(self,
+        xpath: str,
+        multiple: bool = False,
+        toplevel: bool = False,
+        attribute: Optional[str] = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.xpath = xpath
+        self.multiple = multiple
+        self.toplevel = toplevel
+        self.attribute = attribute
+
+    def _select(self, element: Element, root: Element) -> List[Element]:
+        el = root if self.toplevel else element
+        if self.multiple:
+            return el.findall(self.xpath)
+        else:
+            return [el.find(self.xpath)]
+
+
+    def _extract(self, element: Element):
+        if self.attribute:
+            return element.get(self.attribute, None)
+        return element.text
+
+
+    def _apply(self, element: Element, root: Element, *nargs, **kwargs):
+        elements = self._select(element, root)
+        if self.multiple:
+            return list(map(self._extract, elements))
+        else:
+            if len(elements):
+                return self._extract(elements[0])
 
 
 class CSV(Extractor):

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -486,40 +486,12 @@ class XPath(Extractor):
     Extractor for XML data from the EtreeXMLReader
     '''
 
-    def __init__(self,
-        xpath: str,
-        multiple: bool = False,
-        toplevel: bool = False,
-        attribute: Optional[str] = None,
-        **kwargs
-    ):
+    def __init__(self, xpath: str, **kwargs):
         super().__init__(**kwargs)
         self.xpath = xpath
-        self.multiple = multiple
-        self.toplevel = toplevel
-        self.attribute = attribute
 
-    def _select(self, element, root) -> List:
-        el = root if self.toplevel else element
-        if self.multiple:
-            return el.findall(self.xpath)
-        else:
-            return [el.find(self.xpath)]
-
-
-    def _extract(self, element):
-        if self.attribute:
-            return element.get(self.attribute, None)
-        return element.text
-
-
-    def _apply(self, element, root, *nargs, **kwargs):
-        elements = self._select(element, root)
-        if self.multiple:
-            return list(map(self._extract, elements))
-        else:
-            if len(elements):
-                return self._extract(elements[0])
+    def _apply(self, element, *nargs, **kwargs):
+        return element.xpath(self.xpath)
 
 
 class CSV(Extractor):

--- a/ianalyzer_readers/readers/etree.py
+++ b/ianalyzer_readers/readers/etree.py
@@ -1,6 +1,6 @@
 from lxml import etree
 
-from ianalyzer_readers.readers.core import Reader, Field
+from ianalyzer_readers.readers.core import Reader
 from ianalyzer_readers import extract
 from requests import Response
 
@@ -10,7 +10,6 @@ class EtreeXMLReader(Reader):
     path_entry: str
 
     def validate(self):
-        # make sure the field size is as big as the system permits
         self._reject_extractors(extract.XML, extract.CSV, extract.JSON, extract.RDF)
 
 
@@ -29,5 +28,5 @@ class EtreeXMLReader(Reader):
     def iterate_data(self, data: etree.ElementTree, metadata):
         root = data.getroot()
 
-        for element in root.findall(self.path_entry):
-            yield { 'element': element, 'root': root }
+        for element in root.xpath(self.path_entry):
+            yield { 'element': element }

--- a/ianalyzer_readers/readers/etree.py
+++ b/ianalyzer_readers/readers/etree.py
@@ -28,5 +28,5 @@ class EtreeXMLReader(Reader):
     def iterate_data(self, data: etree.ElementTree, metadata):
         root = data.getroot()
 
-        for element in root.xpath(self.path_entry):
+        for element in root.iterfind(self.path_entry):
             yield { 'element': element }

--- a/ianalyzer_readers/readers/etree.py
+++ b/ianalyzer_readers/readers/etree.py
@@ -6,8 +6,18 @@ from requests import Response
 
 
 class EtreeXMLReader(Reader):
+    '''
+    Alternative to the XMLReader
+
+    - Built on lxml instead of BeautifulSoup
+    - Pairs with the `XPath` extractor: queries for fields are provided as XPath
+        expressions.
+
+    Faster than the XMLReader (I think?) at the cost of feature support.
+    '''
 
     path_entry: str
+    'Path expression to select document entry points'
 
     def validate(self):
         self._reject_extractors(extract.XML, extract.CSV, extract.JSON, extract.RDF)

--- a/ianalyzer_readers/readers/etree.py
+++ b/ianalyzer_readers/readers/etree.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+from lxml import etree
 
 from ianalyzer_readers.readers.core import Reader, Field
 from ianalyzer_readers import extract
@@ -12,10 +12,10 @@ class EtreeXMLReader(Reader):
         self._reject_extractors(extract.XML, extract.CSV, extract.JSON, extract.RDF)
     
     def data_from_file(self, path):
-        tree = ET.parse(path)
+        tree = etree.parse(path)
         return tree
 
-    def iterate_data(self, data: ET.ElementTree, metadata):
+    def iterate_data(self, data: etree.ElementTree, metadata):
         root = data.getroot()
 
         for element in root.findall(self.path_entry):

--- a/ianalyzer_readers/readers/etree.py
+++ b/ianalyzer_readers/readers/etree.py
@@ -2,6 +2,8 @@ from lxml import etree
 
 from ianalyzer_readers.readers.core import Reader, Field
 from ianalyzer_readers import extract
+from requests import Response
+
 
 class EtreeXMLReader(Reader):
 
@@ -10,10 +12,19 @@ class EtreeXMLReader(Reader):
     def validate(self):
         # make sure the field size is as big as the system permits
         self._reject_extractors(extract.XML, extract.CSV, extract.JSON, extract.RDF)
-    
+
+
     def data_from_file(self, path):
-        tree = etree.parse(path)
-        return tree
+        return etree.parse(path)
+
+
+    def data_from_bytes(self, bytes):
+        return etree.parse(bytes)
+
+
+    def data_from_response(self, response: Response):
+        return etree.XML(response.content)
+
 
     def iterate_data(self, data: etree.ElementTree, metadata):
         root = data.getroot()

--- a/ianalyzer_readers/readers/etree.py
+++ b/ianalyzer_readers/readers/etree.py
@@ -1,0 +1,22 @@
+import xml.etree.ElementTree as ET
+
+from ianalyzer_readers.readers.core import Reader, Field
+from ianalyzer_readers import extract
+
+class EtreeXMLReader(Reader):
+
+    path_entry: str
+
+    def validate(self):
+        # make sure the field size is as big as the system permits
+        self._reject_extractors(extract.XML, extract.CSV, extract.JSON, extract.RDF)
+    
+    def data_from_file(self, path):
+        tree = ET.parse(path)
+        return tree
+
+    def iterate_data(self, data: ET.ElementTree, metadata):
+        root = data.getroot()
+
+        for element in root.findall(self.path_entry):
+            yield { 'element': element, 'root': root }

--- a/tests/xml/test_etree_xml_reader.py
+++ b/tests/xml/test_etree_xml_reader.py
@@ -7,7 +7,7 @@ from test_xml_reader import target_documents
 
 class HamletEtreeXMLReader(EtreeXMLReader):
     data_directory = os.path.join(os.path.dirname(__file__), 'data')
-    path_entry = '/document/content/act/scene/lines'
+    path_entry = 'content/act/scene/lines'
 
     def sources(self, **kwargs):
         for filename in os.listdir(self.data_directory):

--- a/tests/xml/test_etree_xml_reader.py
+++ b/tests/xml/test_etree_xml_reader.py
@@ -1,0 +1,38 @@
+import os
+
+from ianalyzer_readers.readers.core import Field
+from ianalyzer_readers.readers.etree import EtreeXMLReader
+from ianalyzer_readers.extract import XPath
+from test_xml_reader import target_documents
+
+class HamletEtreeXMLReader(EtreeXMLReader):
+    data_directory = os.path.join(os.path.dirname(__file__), 'data')
+    path_entry = './content/act/scene/lines'
+
+    def sources(self, **kwargs):
+        for filename in os.listdir(self.data_directory):
+            full_path = os.path.join(self.data_directory, filename)
+            yield full_path
+
+
+    title = Field(
+        'title',
+        XPath('./meta/title', toplevel=True),
+    )
+    character = Field(
+        'character',
+        XPath('.', attribute='character')
+    )
+    lines = Field(
+        'lines',
+        XPath('l', multiple=True, transform='\n'.join)
+    )
+
+    fields = [character, lines, title]
+
+def test_etree_xml_reader():
+    reader = HamletEtreeXMLReader()
+    docs = reader.documents()
+
+    for doc, target in zip(docs, target_documents):
+        assert doc == target

--- a/tests/xml/test_etree_xml_reader.py
+++ b/tests/xml/test_etree_xml_reader.py
@@ -7,7 +7,7 @@ from test_xml_reader import target_documents
 
 class HamletEtreeXMLReader(EtreeXMLReader):
     data_directory = os.path.join(os.path.dirname(__file__), 'data')
-    path_entry = './content/act/scene/lines'
+    path_entry = '/document/content/act/scene/lines'
 
     def sources(self, **kwargs):
         for filename in os.listdir(self.data_directory):
@@ -17,15 +17,15 @@ class HamletEtreeXMLReader(EtreeXMLReader):
 
     title = Field(
         'title',
-        XPath('./meta/title', toplevel=True),
+        XPath('string(/document/meta/title/text())'),
     )
     character = Field(
         'character',
-        XPath('.', attribute='character')
+        XPath('string(@character)')
     )
     lines = Field(
         'lines',
-        XPath('l', multiple=True, transform='\n'.join)
+        XPath('l/text()', transform='\n'.join)
     )
 
     fields = [character, lines, title]
@@ -34,5 +34,5 @@ def test_etree_xml_reader():
     reader = HamletEtreeXMLReader()
     docs = reader.documents()
 
-    for doc, target in zip(docs, target_documents):
+    for doc, target in zip(docs, target_documents, strict=True):
         assert doc == target


### PR DESCRIPTION
Defines an alternative XML reader based on `lxml` (without Beautiful soup). The class is very simple; extractors are defined using XPath. The unit tests include some examples.

This reader is generally much faster than the `XMLReader`, but offers fewer features. (The speed gain is mostly in the initial parsing of the XML file.)

This was built as a proof-of-concept, but we're not planning to merge it currently. We don't want to replace the XMLReader with this one (due to the lack of features), or have two readers side-by-side.

The tests currently fail for Python 3.9, due to a compatibility issue in the test itself; the reader should work fine in Python 3.9.