### PR TITLE
Feature/cache extractor

### DIFF
--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -288,20 +288,24 @@ class Pass(Extractor):
 
 class Order(Extractor):
     '''
-    An extractor that returns the index of the document in its
-    source file.
-
-    The index of the document needs to be passed on the by `Reader`, which needs to
-    implement some kind of counter in its `source2dicts` method. The `Reader` subclasses
-    in this package all implement this, and so `Order` can safely be used in any of them.
-    However, custom `Reader` subclasses may not support this extractor.
+    An extractor to keep track of the order of documents. By default, this is the order
+    of documents within their source, but you can also track the order of sources.
 
     Parameters:
+        level: Can be `'document'` or `'source'`. Whether to return the index of the
+            source, or of the document within the source.
         **kwargs: additional options to pass on to `Extractor`.
     '''
 
-    def _apply(self, index: int = None, *nargs, **kwargs):
-        return index
+    def __init__(self, level: str = 'document', **kwargs):
+        self.level = level
+        super().__init__(**kwargs)
+
+    def _apply(self, index: int = None, source_index: int = None, **kwargs):
+        if self.level == 'document':
+            return index
+        if self.level == 'source':
+            return source_index
 
 
 class Cache(Extractor):

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -11,11 +11,13 @@ import logging
 import traceback
 from typing import Any, Dict, Callable, Union, List, Optional, Iterable
 import warnings
+from functools import lru_cache
 
 import bs4
 import html
 from rdflib import BNode, Graph, Literal, URIRef
 from rdflib.collection import Collection
+
 
 logger = logging.getLogger()
 
@@ -300,6 +302,45 @@ class Order(Extractor):
 
     def _apply(self, index: int = None, *nargs, **kwargs):
         return index
+
+
+class Cache(Extractor):
+    '''
+    Can be wrapped around another extractor to prevent repeatedly extracting the same
+    value. 
+
+    This is based on an assumption that the value of your extractor is going to
+    be the same within a document, a source file, or even across the whole dataset. The
+    level is specified in the constructor.
+
+    Parameters:
+        extractor: extractor 
+        level: Can be `'document'`, `'source'`, or `'reader'`
+        **kwargs: additional options to pass on to `Extractor`
+    '''
+
+    def __init__(self, extractor: Extractor, level: str = 'document', **kwargs):
+        self.extractor = extractor
+        self.level = level
+        self.kwargs = {}
+        super().__init__(**kwargs)
+
+    def _apply(self, **kwargs):
+        self.kwargs = kwargs
+
+        if self.level == 'document':
+            cache_params = [kwargs['source_index'], kwargs['index']]
+        if self.level == 'source':
+            cache_params = [kwargs['source_index']]
+        if self.level == 'reader':
+            cache_params = []
+        
+        return self._apply_cached(*cache_params)
+
+    @lru_cache(maxsize=1)
+    def _apply_cached(self, *cache_parameters):
+        return self.extractor.apply(**self.kwargs)
+
 
 class XML(Extractor):
     '''

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -309,13 +309,14 @@ class Cache(Extractor):
     Can be wrapped around another extractor to prevent repeatedly extracting the same
     value. 
 
-    This is based on an assumption that the value of your extractor is going to
-    be the same within a document, a source file, or even across the whole dataset. The
-    level is specified in the constructor.
+    Makes an assumption the value of the extractor is going to be the same within a
+    document, a source file, or even across the whole dataset. The level is specified in
+    the constructor.
 
     Parameters:
-        extractor: extractor 
-        level: Can be `'document'`, `'source'`, or `'reader'`
+        extractor: Extractor of which the value is returned and cached.
+        level: The level at which values should be cached. Can be `'document'`,
+            `'source'`, or `'reader'`.
         **kwargs: additional options to pass on to `Extractor`
     '''
 

--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -314,14 +314,37 @@ class Cache(Extractor):
     value. 
 
     Makes an assumption the value of the extractor is going to be the same within a
-    document, a source file, or even across the whole dataset. The level is specified in
-    the constructor.
+    document, a source file, or even across the whole dataset.
 
     Parameters:
         extractor: Extractor of which the value is returned and cached.
         level: The level at which values should be cached. Can be `'document'`,
             `'source'`, or `'reader'`.
         **kwargs: additional options to pass on to `Extractor`
+
+    Note: caching is based on the extractor instance and will not work across instances.
+    For instance, in the example below, there would be no caching across fields.
+
+    ```python
+    fields = [
+        Field(name='foo', extractor=Cache(XML('baz'))),
+        Field(name='bar', extractor=Cache(XML('baz')))
+    ]
+    ```
+
+    You could rewrite this as follows, so the XML tree is only queried once per document:
+
+    ```python
+    _my_extractor = Cache(XML('baz'))
+
+    fields = [
+        Field(name='foo', extractor=_my_extractor),
+        Field(name='bar', extractor=_my_extractor)
+    ]
+    ```
+
+    There is a similar issue when you use `@property` to define the `fields` of the
+    reader.
     '''
 
     def __init__(self, extractor: Extractor, level: str = 'document', **kwargs):

--- a/ianalyzer_readers/readers/core.py
+++ b/ianalyzer_readers/readers/core.py
@@ -169,7 +169,7 @@ class Reader:
         '''
         raise NotImplementedError('Reader missing sources implementation')
 
-    def source2dicts(self, source: Source) -> Iterable[Document]:
+    def source2dicts(self, source: Source, source_index=-1) -> Iterable[Document]:
         '''
         Given a source file, returns an iterable of extracted documents.
 
@@ -193,7 +193,11 @@ class Reader:
         
         with context_manager as data:
             for index, extracted_data in enumerate(self.iterate_data(data, metadata)):
-                base_data = {'metadata': metadata, 'index': index}
+                base_data = {
+                    'metadata': metadata,
+                    'index': index,
+                    'source_index': source_index,
+                }
                 document_data = base_data | extracted_data
                 document = self.extract_document(**document_data)
                 if self._has_required_fields(document):
@@ -355,12 +359,13 @@ class Reader:
                 are based on the extractor of each field.
         '''
         sources = sources or self.sources()
-        return (document
-                for source in sources
-                for document in self.source2dicts(
-                    source
-                )
-                )
+        return (
+            document
+            for i, source in enumerate(sources)
+            for document in self.source2dicts(
+                source, source_index=i
+            )
+        )
 
     def export_csv(self, path: str, sources: Optional[Iterable[Source]] = None) -> None:
         '''

--- a/tests/test_generic_extractors.py
+++ b/tests/test_generic_extractors.py
@@ -1,6 +1,6 @@
 import pytest
 from ianalyzer_readers.extract import (
-    Constant, Combined, Backup, Choice, Metadata, Pass, Order
+    Constant, Combined, Backup, Choice, Metadata, Pass, Order, Cache
 )
 
 def test_constant_extractor():
@@ -85,3 +85,33 @@ def test_extractor_applicable_callable():
         extractor = Constant('test', applicable=lambda metadata: metadata['testing'])
     assert extractor.apply(metadata={'testing': True}) == 'test'
     assert extractor.apply(metadata={'testing': False}) == None
+
+
+@pytest.mark.parametrize('level', ['document', 'source', 'reader'])
+def test_cache_extractor(level):
+    called = 0
+
+    def keep_count(value):
+        nonlocal called
+        called += 1
+        return value
+    
+    extractor = Cache(
+        Constant('test', transform=keep_count),
+        level=level,
+    )
+
+    sources = 2
+    docs_per_source = 3
+    fields_per_doc = 5
+
+    for source in range(sources):
+        for doc in range(docs_per_source):
+            for _ in range(fields_per_doc):
+                assert extractor.apply(source_index=source, index=doc) == 'test'
+
+    expected_calls = {
+        'document': sources * docs_per_source, 'source': sources, 'reader': 1
+    }
+
+    assert called == expected_calls[level]

--- a/tests/test_generic_extractors.py
+++ b/tests/test_generic_extractors.py
@@ -73,6 +73,11 @@ def test_order_extractor():
     output = extractor.apply(index=1)
     assert output == 1
 
+def test_order_extractor_source_level():
+    extractor = Order(level='source')
+    output = extractor.apply(source_index=1, index=3)
+    assert output == 1
+
 
 def test_extractor_applicable_extractor():
     extractor = Constant('test', applicable=Metadata('testing'))


### PR DESCRIPTION
Adds a `Cache` extractor, which can be useful to avoid repeatedly extracting the same value.

This implementation required tracking the source iteration, so I also added a `level` parameter to the `Order` extractor (as the data is provided now).