### PR TITLE
allow empty list for JSON keys

### DIFF
--- a/ianalyzer_readers/extract.py
+++ b/ianalyzer_readers/extract.py
@@ -619,7 +619,8 @@ class JSON(Extractor):
     When working with nested lists, use JSONReader to unnest.
 
     Parameters:
-        keys (Iterable[str]): the keys with which to retrieve a field value from the source
+        keys (Iterable[str]): the keys with which to retrieve a field value from the
+            source. If empty, this returns the source as-is.
     '''
 
     def __init__(self, *keys, **kwargs):
@@ -627,6 +628,8 @@ class JSON(Extractor):
         super().__init__(**kwargs)
 
     def _apply(self, data: Union[str, dict], key_index: int = 0, **kwargs) -> str:
+        if not len(self.keys):
+            return data
         key = self.keys[key_index]
         data = data.get(key)
         if len(self.keys) > key_index + 1:

--- a/tests/test_json_reader.py
+++ b/tests/test_json_reader.py
@@ -1,4 +1,6 @@
 from tests.json.json_reader import JSONDocumentReader, JSONMultipleDocumentReader
+from ianalyzer_readers.readers.core import Field
+from ianalyzer_readers.extract import JSON
 
 expected = [
     {
@@ -41,3 +43,10 @@ def _assert_matches(target: dict, doc: dict):
     assert len(target.keys()) == len(doc.keys())
     for key in target.keys():
         assert doc.get(key) == target.get(key)
+
+def test_json_no_key():
+    reader = JSONDocumentReader()
+    field = Field('data', extractor=JSON())
+    reader.fields.append(field)
+    doc = next(reader.documents())
+    assert 'TITLE' in doc['data']


### PR DESCRIPTION
Allows the `keys` parameter for the `JSON` extractor to be empty, to extract the root object.