### PR TITLE
Feature/combined reader

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -42,6 +42,13 @@ __Module:__ `ianalyzer_readers.readers.json`
 
 ::: ianalyzer_readers.readers.json
 
+## Combined reader
+
+__Module:__ `ianalyzer_readers.readers.combined`
+
+::: ianalyzer_readers.readers.combined
+
+
 ## Extractors
 
 __Module:__ `ianalyzer_readers.extract`

--- a/docs/combining_readers.md
+++ b/docs/combining_readers.md
@@ -1,0 +1,147 @@
+# Combining multiple readers
+
+It's common for dataset to include multiple data formats, where it's useful to combine different `Reader` classes. This is necessary when you're reading multiple file formats, e.g. CSV and XML. It can also make sense when your data uses the same file format, but different data formats. (For example, CSV files with completely different column names.)
+
+In our experience, these are the most common scenarios:
+
+1. You need to concatenate the output from multiple readers.
+2. You need one reader to parse an index file, which gives you the filenames for the content files. The content data is in another format, so this requires another reader.
+3. You want to iterate through a dataset with one reader, but cross-reference it with another dataset to fill in some fields. (Effectively doing a table join.)
+
+These are very different scenarios, so we will go over each below.
+
+## Concatenating documents
+
+In this scenario, different portions of your data use a different format. You can write a reader for each portion, and then create a reader that will iterate through each of these in turn.
+
+For example, you could work with a dataset where you have one dataset that provides XML data up to a certain data, and another dataset that provides CSV data for a more recent timeframe. Neither of these source datasets covers the entire period you're interested in, but you can combine the outputs from both.
+
+For this scenario, we provide the `ConcatReader` class. After you have created a reader for each portion of your data, you can create a `ConcatReader`, which will concatenate their outputs. This will look something like this:
+
+```python
+from ianalyzer_readers.readers.xml import XMLReader
+from ianalyzer_readers.readers.csv import CSVReader
+from ianalyzer_readers.readers.combined import ConcatReader
+from ianalyzer_readers.readers.core import Fields
+from ianalyzer_readers.extract import XML, CSV
+
+class MyXMLReader(XMLReader):
+    # reader implementation...
+    fields = [
+        Field('foo', extractor=XML(...)),
+        Field('bar', extractor=XML(...)),
+    ]
+
+class MyCSVReader(CSVReader):
+    # reader implementation...
+    fields = [
+        Field('foo', extractor=CSV(...)),
+        Field('baz', extractor=CSV(...)),
+    ]
+
+class MyConcatReader(ConcatReader):
+    reader_classes = [MyXMLReader, MyCSVReader]
+    fields = [
+        Field('foo'),
+        Field('bar'),
+        Field('baz'),
+    ]
+```
+
+`MyConcatReader` will automatically iterate through the XML files, followed by the CSV files.
+
+Some notes:
+- As in the example above, it's okay if the subreaders do not implement every field from the combined reader.
+- The combined reader does not check for overlap between documents, so make sure that the subreaders are not reading overlapping data.
+
+## Using an index reader and a content reader
+
+In this scenario, you have one file format that provides an index of the data. For example, a CSV file that contains a list of XML files, and some metadata for each. You can create a reader class to parse the index file (in this case, the CSV), and then another reader to parse the content files (in this case, the XMLs).
+
+At present, we do not provide a helper class for this, but the logic to combine readers like this is usually straightforward. It consists of the following:
+
+- Create a reader for your index data
+- Create a reader for your content data which initialises the index reader.
+- In the content reader, the `sources()` function should iterate over the `documents()` output from the index reader.
+- You can pass on field values from the index reader as metadata for the content reader.
+
+Here is an example of what this might look like:
+
+```python
+from ianalyzer_readers.readers.xml import XMLReader
+from ianalyzer_readers.readers.csv import CSVReader
+from ianalyzer_readers.readers.core import Fields
+from ianalyzer_readers.extract import XML, CSV
+from ianalyzer_readers.xml_tag import Tag, CurrentTag
+
+class IndexReader(CSVReader):
+    def sources(self, **kwargs):
+        yield 'data.csv'
+    
+    fields = [
+        Field('filename', CSV('file')),
+        Field('publication', CSV('pub')),
+        Field('date', CSV('date')),
+    ]
+
+class ContentReader(XMLReader):
+    def __init__(self):
+        self.index_reader = IndexReader()
+
+    def sources(self, **kwargs):
+        for doc in self.index_reader.sources(**kwargs):
+            filename = doc['filename']
+            yield filename, doc # provide doc values as metadata
+    
+    tag_entry = Tag('article')
+
+    fields = [
+        # fields passed on from index reader
+        Field('publication', Metadata('publication')),
+        Field('date', Metadata('date')),
+        # fields from XML data
+        Field('title', XML(Tag('title'))),
+        Field('author', XML(Tag('by'))),
+        Field('content', XML(Tag('content'))),
+    ]
+```
+
+## Cross-referencing documents
+
+In this scenario, you want to iterate through one dataset, but cross-reference it with values from another dataset. For example, you have one dataset with books that includes an ID for each author, and another dataset that provides information about each author. We do not currently have a standardised solution for this scenario. Below are some techniques we have used in the past.
+
+If the data is not too large, it can work to gather all author data up front (with a specialised reader) and keep it in memory. In the `sources` implementation for your books reader, include the author data in the metadata for each object, with author IDs as keys. Then a field can extract author data like so:
+
+```python
+from ianalyzer_readers.readers.core import Field
+from ianalyzer_readers.extract import Combined, XML, Metadata
+
+Field(
+    'author_name',
+    Combined(
+        Metadata('authors'),
+        XML(attribute='author_id'),
+        transform=lambda data: data[0].get(data[1]).get('name'),
+    )
+)
+```
+
+In this case, you could also consider writing two readers, one for your content data, and one with the author data, and using a library like `pandas` to join the output.
+
+In some cases, you would not know the list of authors up front, and it makes more sense to look up metadata for each author (e.g. through a web API). You can write a lookup function with a cache:
+
+```python
+from functools import cache
+
+@cache
+def get_author_name(id):
+    # do something...
+    return 'John Doe'
+
+Field(
+    'author_name'
+    XML(attribute='author_id', transform=get_author_name)
+)
+```
+
+Note that neither of these methods is suitable if the amount of metadata might exceed your available memory.

--- a/ianalyzer_readers/readers/combined.py
+++ b/ianalyzer_readers/readers/combined.py
@@ -1,9 +1,14 @@
+'''
+Module for "meta-readers" that combine output from other readers. Currently, this is
+just the `ConcatReader`.
+'''
+
 from typing import List, Type
 from ianalyzer_readers.readers.core import Reader, Source
 
-class CombinedReader(Reader):
+class ConcatReader(Reader):
     '''
-    A CombinedReader returns data from multiple subreaders.
+    A ConcatReader returns data from multiple subreaders.
 
     The combined reader will iterate through each subreader in turn and concatenate the
     documents. For example, you could use this when a portion of your data is provided as

--- a/ianalyzer_readers/readers/combined.py
+++ b/ianalyzer_readers/readers/combined.py
@@ -1,0 +1,42 @@
+from typing import List, Type
+from ianalyzer_readers.readers.core import Reader, Source
+
+class CombinedReader(Reader):
+    '''
+    A CombinedReader returns data from multiple subreaders.
+
+    The combined reader will iterate through each subreader in turn and concatenate the
+    documents. For example, you could use this when a portion of your data is provided as
+    XML files, and another portion as CSV files.
+
+    To make a working combined reader, you need to implement `reader_classes`, which
+    provides the classes of the subreaders, and `fields`. The fields do not need
+    (or use) extractors. Field values are taken directly from the subreader by matching
+    the name. If a subreader does not implement a field, its value will be `None`.
+
+    Attributes:
+        reader_classes: List of classes for subreaders.
+    '''
+
+    reader_classes: List[Type[Reader]]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.readers = [cls(**kwargs) for cls in self.reader_classes]
+
+
+    def sources(self, **kwargs):
+        for i, reader in enumerate(self.readers):
+            for source in reader.sources(**kwargs):
+                source_data, metadata = self._split_metadata(source)
+                metadata = metadata | {'reader_index': i}
+                yield source_data, metadata
+
+
+    def source2dicts(self, source: Source, **kwargs):
+        _, metadata = self._split_metadata(source)
+        reader: Reader = self.readers[metadata['reader_index']]
+        docs = reader.source2dicts(source, **kwargs)
+
+        for doc in docs:
+            yield {field.name: doc.get(field.name, None) for field in self.fields}

--- a/ianalyzer_readers/readers/core.py
+++ b/ianalyzer_readers/readers/core.py
@@ -215,11 +215,7 @@ class Reader:
             A tuple with the parsed source data, and the metadata (empty if none was
                 provided).
         '''
-        if isinstance(source, tuple) and len(source) == 2:
-            source_data, metadata = source
-        else:
-            source_data = source
-            metadata = {}
+        source_data, metadata = self._split_metadata(source)
 
         if isinstance(source_data, str):
             if not isfile(source_data):
@@ -233,6 +229,14 @@ class Reader:
             raise TypeError(f'Unknown source type: {type(source_data)}')
 
         return data, metadata
+
+
+    def _split_metadata(self, source: Source) -> Tuple[SourceData, Dict]:
+        '''Splits a source into the (unparsed) source object and metadata'''
+        if isinstance(source, tuple) and len(source) == 2:
+            return source
+        else:
+            return source, {}
 
 
     def data_from_file(self, path: str) -> Any:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
     - 'example_csv.md'
     - 'example_xml.md'
     - 'example_custom.md'
+    - 'combining_readers.md'
   - 'api.md'
 watch:
   - docs

--- a/tests/test_combined_reader.py
+++ b/tests/test_combined_reader.py
@@ -1,11 +1,11 @@
-from ianalyzer_readers.readers.combined import CombinedReader
+from ianalyzer_readers.readers.combined import ConcatReader
 from ianalyzer_readers.readers.core import Field
 
 from tests.json.json_reader import JSONMultipleDocumentReader as JSONShakespeareReader
 from tests.csv.test_csv_reader import ShakespeareReader as CSVShakespeareReader
 
 
-class CombinedShakespeareReader(CombinedReader):
+class CombinedShakespeareReader(ConcatReader):
     reader_classes = [CSVShakespeareReader, JSONShakespeareReader]
     fields = [
         Field(name='play'),

--- a/tests/test_combined_reader.py
+++ b/tests/test_combined_reader.py
@@ -1,0 +1,31 @@
+from ianalyzer_readers.readers.combined import CombinedReader
+from ianalyzer_readers.readers.core import Field
+
+from tests.json.json_reader import JSONMultipleDocumentReader as JSONShakespeareReader
+from tests.csv.test_csv_reader import ShakespeareReader as CSVShakespeareReader
+
+
+class CombinedShakespeareReader(CombinedReader):
+    reader_classes = [CSVShakespeareReader, JSONShakespeareReader]
+    fields = [
+        Field(name='play'),
+        Field(name='act'),
+        Field(name='character'),
+        Field(name='scene'),
+        Field(name='lines'),
+        Field(name='stage_direction'),
+    ]
+
+def test_combined_reader():
+    reader = CombinedShakespeareReader()
+    docs = list(reader.documents())
+
+    subreader_1 = CSVShakespeareReader()
+    subreader_1_docs = list(subreader_1.documents())
+    subreader_2 = JSONShakespeareReader()
+    subreader_2_docs = list(subreader_2.documents())
+
+    assert len(docs) == len(subreader_1_docs) + len(subreader_2_docs) == 36
+    assert docs[0].items() >= subreader_1_docs[0].items()
+    assert len(docs[0]) == 6
+    assert docs[len(subreader_1_docs)].items() >= subreader_2_docs[0].items()


### PR DESCRIPTION
- Adds a `ConcatReader`, to concatenate output from multiple readers. A few corpora in Textcavator already use more or less this logic, this is just to outfactor it.
- Adds a documentation file that goes over a few scenarios for combining readers.