### PR TITLE
fix rds reader

### DIFF
--- a/textcavator_readers/readers/rds.py
+++ b/textcavator_readers/readers/rds.py
@@ -18,10 +18,11 @@ class RDSReader(Reader):
 
     def data_from_file(self, path: str) -> Iterable[Dict]:
         result = pyreadr.read_r(path)
-        data: pandas.DataFrame = result['data']
+        for value in result.values():
+            data: pandas.DataFrame = value
 
-        for _, row in data.iterrows():
-            yield {index: value for index, value in row.items()}
+            for _, row in data.iterrows():
+                yield {index: value for index, value in row.items()}
 
     def iterate_data(self, data: Iterable[Dict], metadata: Dict):
         for row in data:


### PR DESCRIPTION
Changes the RDS reader implementation to match the one currently in Textcavator: https://github.com/CentreForDigitalHumanities/Textcavator/blob/develop/backend/corpora/parliament/utils/rds_reader.py

Apparently the current implementation does not work for the data in Textcavator, not sure why I changed it. But this fixes the issue.